### PR TITLE
Handlers can return arrays + enable preprocessing

### DIFF
--- a/packages/html-to-structured-text/README.md
+++ b/packages/html-to-structured-text/README.md
@@ -1,11 +1,11 @@
-# `to-dast`
+# `html-to-structured-text`
 
 > TODO: description
 
 ## Usage
 
 ```
-const toDast = require('to-dast');
+const { toDast } = require('html-to-structured-text');
 
 // TODO: DEMONSTRATE API
 ```

--- a/packages/html-to-structured-text/__tests__/index.test.ts
+++ b/packages/html-to-structured-text/__tests__/index.test.ts
@@ -748,4 +748,27 @@ describe('toDast', () => {
       });
     });
   });
+
+  describe('preprocessing', () => {
+    it('allows users to transform the Hast tree', async () => {
+      const html = `
+        <p>heading</p>
+      `;
+      const dast = await htmlToDast(html, {
+        preprocess: (tree) => {
+          findAll(tree, (node) => {
+            if (node.type === 'element' && node.tagName === 'p') {
+              node.tagName = 'h1';
+            }
+          });
+        },
+      });
+      expect(validate(dast).valid).toBeTruthy();
+      expect(findAll(dast, 'paragraph')).toHaveLength(0);
+      const headings = findAll(dast, 'heading');
+      expect(headings).toHaveLength(1);
+      expect(headings[0].level).toBe(1);
+      expect(find(headings[0], 'span').value).toBe('heading');
+    });
+  });
 });

--- a/packages/html-to-structured-text/__tests__/index.test.ts
+++ b/packages/html-to-structured-text/__tests__/index.test.ts
@@ -71,6 +71,56 @@ describe('toDast', () => {
   });
 
   describe('handlers', () => {
+    it('can return an array of nodes', async () => {
+      const html = `
+        <p>twice</p>
+      `;
+
+      const dast = await htmlToDast(html, {
+        handlers: {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          text: async (createNode, node, context) => {
+            return await Promise.all([
+              createNode('span', {
+                value: node.value,
+              }),
+              createNode('span', {
+                value: node.value,
+              }),
+            ]);
+          },
+          p: async (createNode, node, context) => {
+            return await Promise.all([
+              context.defaultHandlers.p(createNode, node, context),
+              context.defaultHandlers.p(createNode, node, context),
+            ]);
+          },
+        },
+      });
+      expect(validate(dast).valid).toBeTruthy();
+      expect(findAll(dast, 'paragraph')).toHaveLength(2);
+      expect(findAll(dast, 'span')).toHaveLength(4);
+    });
+
+    it('can return an array of promises', async () => {
+      const html = `
+        <p>twice</p>
+      `;
+      const dast = await htmlToDast(html, {
+        handlers: {
+          p: (createNode, node, context) => {
+            return [
+              context.defaultHandlers.p(createNode, node, context),
+              context.defaultHandlers.p(createNode, node, context),
+            ];
+          },
+        },
+      });
+      expect(validate(dast).valid).toBeTruthy();
+      expect(findAll(dast, 'paragraph')).toHaveLength(2);
+      expect(findAll(dast, 'span')).toHaveLength(2);
+    });
+
     describe('custom (user provided)', () => {
       it('can register custom handlers', async () => {
         const html = `

--- a/packages/html-to-structured-text/src/index.ts
+++ b/packages/html-to-structured-text/src/index.ts
@@ -54,6 +54,7 @@ export async function hastToDast(
     name: 'root',
     frozenBaseUrl: null,
     wrapText: true,
+    defaultHandlers: handlers,
     handlers: Object.assign({}, handlers, settings.handlers || {}),
   });
 }

--- a/packages/html-to-structured-text/src/index.ts
+++ b/packages/html-to-structured-text/src/index.ts
@@ -14,6 +14,7 @@ import documentToHast from 'hast-util-from-dom';
 export type Settings = Partial<{
   newlines: boolean;
   handlers: Record<string, CreateNodeFunction>;
+  preprocess: (hast: HastRootNode) => HastRootNode;
 }>;
 
 export async function htmlToDast(
@@ -48,6 +49,10 @@ export async function hastToDast(
     props.type = type;
     return props;
   };
+
+  if (typeof settings.preprocess === 'function') {
+    settings.preprocess(tree);
+  }
 
   return await visitNode(createNode, tree, {
     parentNode: null,

--- a/packages/html-to-structured-text/src/index.ts
+++ b/packages/html-to-structured-text/src/index.ts
@@ -7,7 +7,7 @@ import minify from 'rehype-minify-whitespace';
 import { Root, CreateNodeFunction, HastRootNode } from './lib/types';
 import visitNode from './lib/visit-node';
 import { handlers } from './lib/handlers';
-import parse5 from '@types/parse5';
+import parse5 from 'parse5';
 import parse5DocumentToHast from 'hast-util-from-parse5';
 import documentToHast from 'hast-util-from-dom';
 

--- a/packages/html-to-structured-text/src/lib/types.ts
+++ b/packages/html-to-structured-text/src/lib/types.ts
@@ -22,7 +22,9 @@ export type Handler<HastNodeType> = (
   createNodeFunction: CreateNodeFunction,
   node: HastNodeType,
   context: Context,
-) => Promise<Node | Array<Node> | void>;
+) =>
+  | Promise<Node | Array<Node> | void>
+  | Array<Promise<Node | Array<Node> | void>>;
 
 export interface HastProperties {
   className?: string[];

--- a/packages/html-to-structured-text/src/lib/visit-children.ts
+++ b/packages/html-to-structured-text/src/lib/visit-children.ts
@@ -11,21 +11,23 @@ export default (async function visitChildren(createNode, parentNode, context) {
   let result;
 
   while (++index < nodes.length) {
-    result = await visitNode(createNode, nodes[index], {
+    result = (await visitNode(createNode, nodes[index], {
       ...context,
       parentNode,
-    });
+    })) as Node | Array<Node | Promise<Node>> | void;
 
     if (result) {
       if (Array.isArray(result)) {
-        result = await Promise.all(
-          result.map((nodeOrPromise) => {
-            if (nodeOrPromise instanceof Promise) {
-              return nodeOrPromise;
-            }
-            return Promise.resolve(nodeOrPromise);
-          }),
-        );
+        result = (await Promise.all(
+          result.map(
+            (nodeOrPromise: Node | Promise<Node>): Promise<Node> => {
+              if (nodeOrPromise instanceof Promise) {
+                return nodeOrPromise;
+              }
+              return Promise.resolve(nodeOrPromise);
+            },
+          ),
+        )) as Array<Node>;
       }
       values = values.concat(result);
     }

--- a/packages/html-to-structured-text/src/lib/visit-children.ts
+++ b/packages/html-to-structured-text/src/lib/visit-children.ts
@@ -17,6 +17,16 @@ export default (async function visitChildren(createNode, parentNode, context) {
     });
 
     if (result) {
+      if (Array.isArray(result)) {
+        result = await Promise.all(
+          result.map((nodeOrPromise) => {
+            if (nodeOrPromise instanceof Promise) {
+              return nodeOrPromise;
+            }
+            return Promise.resolve(nodeOrPromise);
+          }),
+        );
+      }
       values = values.concat(result);
     }
   }


### PR DESCRIPTION
- Adds support for returning an array of nodes from handlers. Optionally converts each item to a Promise to simplify the API.
- Enable preprocessing of the Hast tree through `settings.preprocess`
- Adds reference to default handlers to `context.defaultHandlers`