### PR TITLE
Convert <br> into newlines

### DIFF
--- a/packages/html-to-structured-text/__tests__/all.test.ts
+++ b/packages/html-to-structured-text/__tests__/all.test.ts
@@ -678,6 +678,23 @@ describe('htmlToStructuredText', () => {
         expect(findAll(result.document, 'paragraph')).toHaveLength(1);
         expect(find(result.document, 'span').value).toBe('let dato');
       });
+
+      it('it handles <br> tags', async () => {
+        const html = `
+          <pre><code>foo<br>bar</code></pre>
+        `;
+        const result = await htmlToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(result.document.children).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "code": "foo
+          bar",
+              "type": "code",
+            },
+          ]
+        `);
+      });
     });
 
     describe('blockquote', () => {
@@ -710,6 +727,41 @@ describe('htmlToStructuredText', () => {
             ],
             "type": "blockquote",
           }
+        `);
+      });
+
+      it('supports <br>', async () => {
+        const html = `
+          <blockquote>1<br>2</blockquote>
+        `;
+        const result = await htmlToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(result.document.children).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "type": "span",
+                      "value": "1",
+                    },
+                    Object {
+                      "type": "span",
+                      "value": "
+          ",
+                    },
+                    Object {
+                      "type": "span",
+                      "value": "2",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "blockquote",
+            },
+          ]
         `);
       });
 

--- a/packages/html-to-structured-text/src/handlers.ts
+++ b/packages/html-to-structured-text/src/handlers.ts
@@ -359,6 +359,14 @@ export const span: Handler<HastTextNode> = async function span(
   });
 };
 
+export const newLine: Handler<HastTextNode> = async function newLine(
+  createNode,
+) {
+  return createNode('span', {
+    value: '\n',
+  });
+};
+
 export const inlineCode = withMark('code');
 export const strong = withMark('strong');
 export const italic = withMark('emphasis');
@@ -521,6 +529,7 @@ export const handlers = {
 
   span: extractInlineStyles,
   text: span,
+  br: newLine,
 
   hr: thematicBreak,
 


### PR DESCRIPTION
It seems we don't handle `<br>` to `\n` conversions! (See also #10)