### PR TITLE
Contentful to structured text

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Monorepo with Typescript libraries for handling and rendering [DatoCMS Structure
   - Vue component that you can use to render Structured Text documents.
 - [`datocms-structured-text-to-dom-nodes`](https://github.com/datocms/structured-text/tree/master/packages/to-dom-nodes)
   - DOM nodes renderer for the DatoCMS Structured Text field type. To be used inside the browser, as it expects to find `document.createElement`.
+- [`datocms-contentful-to-structured-text`](https://github.com/datocms/structured-text/tree/master/packages/contentful-to-structured-text)
+  - Convert Contentful Rich Text to a valid Structured Text document.
 
 ## About Structured Text
 

--- a/packages/contentful-to-structured-text/LICENSE.md
+++ b/packages/contentful-to-structured-text/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/contentful-to-structured-text/README.md
+++ b/packages/contentful-to-structured-text/README.md
@@ -1,0 +1,11 @@
+# `contentful-to-structured-text`
+
+> TODO: description
+
+## Usage
+
+```
+const contentfulToStructuredText = require('contentful-to-structured-text');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/contentful-to-structured-text/README.md
+++ b/packages/contentful-to-structured-text/README.md
@@ -1,11 +1,164 @@
-# `contentful-to-structured-text`
+# `datocms-contentful-to-structured-text`
 
-> TODO: description
+This package contains utilities to convert Contentful Rich Text to a DatoCMS Structured Text `dast` (DatoCMS Abstract Syntax Tree) document.
+
+Please refer to [the `dast` format docs](https://www.datocms.com/docs/structured-text/dast) to learn more about the syntax tree format and the available nodes.
 
 ## Usage
 
-```
-const contentfulToStructuredText = require('contentful-to-structured-text');
+The main utility in this package is `richTextToStructuredText` which takes a Rich Text JSON and transforms it into a valid `dast` document.
 
-// TODO: DEMONSTRATE API
+`richTextToStructuredText` returns a `Promise` that resolves with a Structured Text document.
+
+```js
+import { richTextToStructuredText } from 'datocms-contentful-to-structured-text';
+
+const richText = {
+  nodeType: 'document',
+  data: {},
+  content: [
+    {
+      nodeType: 'heading-1',
+      content: [
+        {
+          nodeType: 'text',
+          value: 'Lorem ipsum dolor sit amet',
+          marks: [],
+          data: {},
+        },
+      ],
+      data: {},
+    },
+};
+
+richTextToStructuredText(richText).then((structuredText) => {
+  console.log(structuredText);
+});
 ```
+
+## Validate `dast` documents
+
+`dast` is a strict format for DatoCMS' Structured Text fields. As such the resulting document is generally a simplified, content-centric version of the input HTML.
+
+The `datocms-structured-text-utils` package provides a `validate` utility to validate a value to make sure that the resulting tree is compatible with DatoCMS' Structured Text field.
+
+```js
+import { validate } from 'datocms-structured-text-utils';
+
+// ...
+
+richTextToStructuredText(html).then((structuredText) => {
+  const { valid, message } = validate(structuredText);
+
+  if (!valid) {
+    throw new Error(message);
+  }
+});
+```
+
+We recommend to validate every `dast` to avoid errors later when creating records.
+
+## Advanced Usage
+
+### Options
+
+All the `*ToStructuredText` utils accept an optional `options` object as second argument:
+
+```js
+type Options = Partial<{
+  newlines: boolean,
+  // Override existing Contentful node handlers or add new ones.
+  handlers: Record<string, CreateNodeFunction>,
+  // Array of allowed Block nodes.
+  allowedBlocks: Array<
+    BlockquoteType | CodeType | HeadingType | LinkType | ListType,
+  >,
+  // Array of allowed marks.
+  allowedMarks: Mark[],
+}>;
+```
+
+### Transforming Nodes
+
+The utils in this library traverse a `Contentful Rich Text` tree and transform supported nodes to `dast` nodes. The transformation is done by working on a `Contentful Rich Text` node with a handler (async) function.
+
+Handlers are associated to `Contentful Rich Text` nodes by `nodeType` and look as follow:
+
+```js
+import { visitChildren } from 'datocms-contentful-to-structured-text';
+
+// Handler for the paragraph node type.
+async function p(createDastNode, contentfulNode, context) {
+  return createDastNode('paragraph', {
+    children: await visitChildren(createDastNode, contentfulNode, context),
+  });
+}
+```
+
+Handlers can return either a promise that resolves to a `dast` node, an array of `dast` Nodes or `undefined` to skip the current node.
+
+To ensure that a valid `dast` is generated the default handlers also check that the current `contentfulNode` is a valid `dast` node for its parent and, if not, they ignore the current node and continue visiting its children.
+
+Information about the parent `dast` node name is available in `context.parentNodeType`.
+
+Please take a look at the [default handlers implementation](./handlers.ts) for examples.
+
+The default handlers are available on `context.defaultHandlers`.
+
+### Context
+
+Every handler receives a `context` object that includes the following information:
+
+```js
+export interface GlobalContext {
+  // Whether the library has found a <base> tag or should not look further.
+  // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
+  baseUrlFound?: boolean;
+  // <base> tag url. This is used for resolving relative URLs.
+  baseUrl?: string;
+}
+
+export interface Context {
+  // The current parent `dast` node type.
+  parentNodeType: NodeType;
+  // The parent `Contentful Rich Text` node.
+  parentNode: ContentfulNode;
+  // A reference to the current handlers - merged default + user handlers.
+  handlers: Record<string, Handler<unknown>>;
+  // A reference to the default handlers record (map).
+  defaultHandlers: Record<string, Handler<unknown>>;
+  // Marks for span nodes.
+  marks?: Mark[];
+  // Array of allowed Block types.
+  allowedBlocks: Array<
+    BlockquoteType | CodeType | HeadingType | LinkType | ListType,
+  >;
+  // Array of allowed marks.
+  allowedMarks: Mark[];
+  // Properties in this object are avaliable to every handler as Context
+  // is not deeply cloned.
+  global: GlobalContext;
+}
+```
+
+### Custom Handlers
+
+It is possible to register custom handlers and override the default behavior via options:
+
+```js
+import { paragraphHandler } from './customHandlers';
+
+richTextToStructuredText(html, {
+  handlers: {
+    paragraph: paragraphHandler,
+  },
+}).then((structuredText) => {
+  console.log(structuredText);
+});
+```
+
+It is **highly encouraged** to validate the `dast` when using custom handlers because handlers are responsible for dictating valid parent-children relationships and therefore generating a tree that is compliant with DatoCMS' Structured Text.
+
+## License
+
+MIT

--- a/packages/contentful-to-structured-text/README.md
+++ b/packages/contentful-to-structured-text/README.md
@@ -111,9 +111,6 @@ Every handler receives a `context` object that includes the following informatio
 
 ```js
 export interface GlobalContext {
-  // Whether the library has found a <base> tag or should not look further.
-  // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
-  baseUrlFound?: boolean;
   // <base> tag url. This is used for resolving relative URLs.
   baseUrl?: string;
 }
@@ -157,7 +154,7 @@ richTextToStructuredText(html, {
 });
 ```
 
-It is **highly encouraged** to validate the `dast` when using custom handlers because handlers are responsible for dictating valid parent-children relationships and therefore generating a tree that is compliant with DatoCMS' Structured Text.
+It is **highly encouraged** to validate the `dast` when using custom handlers because handlers are responsible for dictating valid parent-children relationships and therefore generating a tree that is compliant with DatoCMS Structured Text.
 
 ## License
 

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -1,8 +1,651 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+
 import { richTextToStructuredText } from '../src';
+import { allowedChildren, Span, validate } from 'datocms-structured-text-utils';
 
 describe('contentful-to-structured-text', () => {
-  it('needs tests', async () => {
-    const result = await richTextToStructuredText();
-    expect(result).toBeFalsy();
+  it('works with empty document', async () => {
+    const html = '';
+    const result = await richTextToStructuredText(html);
+    expect(validate(result).valid).toBeTruthy();
+    expect(result).toMatchInlineSnapshot(`null`);
+  });
+
+  it('rejects invalid rich text documents', async () => {
+    const html = '';
+    const result = await richTextToStructuredText(html);
+    expect(validate(result).valid).toBeTruthy();
+    expect(result).toMatchInlineSnapshot(`null`);
+  });
+
+  describe('handlers', () => {
+    it('can return an array of nodes', async () => {
+      const html = `
+        <p>twice</p>
+      `;
+
+      const result = await richTextToStructuredText(html, {
+        handlers: {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          text: async (createNode, node, context) => {
+            return await Promise.all([
+              createNode('span', {
+                value: node.value,
+              }),
+              createNode('span', {
+                value: node.value,
+              }),
+            ]);
+          },
+          p: async (createNode, node, context) => {
+            return await Promise.all([
+              context.defaultHandlers.p(createNode, node, context),
+              context.defaultHandlers.p(createNode, node, context),
+            ]);
+          },
+        },
+      });
+      expect(validate(result).valid).toBeTruthy();
+      expect(findAll(result.document, 'paragraph')).toHaveLength(2);
+      expect(findAll(result.document, 'span')).toHaveLength(4);
+    });
+
+    it('can return an array of promises', async () => {
+      const html = `
+        <p>twice</p>
+      `;
+      const result = await richTextToStructuredText(html, {
+        handlers: {
+          p: (createNode, node, context) => {
+            return [
+              context.defaultHandlers.p(createNode, node, context),
+              context.defaultHandlers.p(createNode, node, context),
+            ];
+          },
+        },
+      });
+      expect(validate(result).valid).toBeTruthy();
+      expect(findAll(result.document, 'paragraph')).toHaveLength(2);
+      expect(findAll(result.document, 'span')).toHaveLength(2);
+    });
+
+    describe('custom (user provided)', () => {
+      it('can register custom handlers', async () => {
+        const html = `
+          <unknown>span</unknown>
+        <p>already wrapped</p>
+        needs wrapping
+      `;
+        const result = await richTextToStructuredText(html, {
+          handlers: {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            unknown: (createNode, node, context) => {
+              return createNode('span', {
+                value: 'custom',
+              });
+            },
+          },
+        });
+        expect(validate(result).valid).toBeTruthy();
+        const spans = findAll(result.document, 'span');
+        expect(spans).toHaveLength(3);
+        expect(spans[0].value).toBe('custom');
+        const paragraphs = findAll(result.document, 'paragraph');
+        expect(paragraphs.map((p) => p.children[0].value))
+          .toMatchInlineSnapshot(`
+          Array [
+            "custom",
+            "already wrapped",
+            "needs wrapping",
+          ]
+        `);
+      });
+
+      it('waits for async handlers to resolve', async () => {
+        const html = `
+          <custom>span</custom>
+      `;
+        const result = await richTextToStructuredText(html, {
+          handlers: {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            custom: async (createNode, node, context) => {
+              await new Promise((resolve) => setTimeout(resolve, 200));
+              return createNode('span', {
+                value: 'custom',
+              });
+            },
+          },
+        });
+        expect(validate(result).valid).toBeTruthy();
+        expect(find(result.document, 'span').value).toBe('custom');
+      });
+
+      it('can override default handlers', async () => {
+        const html = `
+          <blockquote>override</blockquote>
+          <p>regular paragraph</p>
+      `;
+        const result = await richTextToStructuredText(html, {
+          handlers: {
+            blockquote: async (createNode, node, context) => {
+              // turn a blockquote into a paragraph
+              return context.handlers.p(createNode, node, context);
+            },
+          },
+        });
+        expect(validate(result).valid).toBeTruthy();
+        expect(find(result.document, 'blockquote')).toBeFalsy();
+        const paragraphs = findAll(result.document, 'paragraph');
+        expect(paragraphs).toHaveLength(2);
+        expect(find(paragraphs[0], 'span').value).toBe('override');
+        expect(find(paragraphs[1], 'span').value).toBe('regular paragraph');
+      });
+    });
+
+    describe('root', () => {
+      it('generates valid children', async () => {
+        const html = `
+          <h1>heading</h1>
+          <p>paragraph</p>
+          implicit paragraph
+          <blockquote>blockquote</blockquote>
+          <pre>code</pre>
+          <ul><li>list</li></ul>
+          <strong>inline wrapped</strong>
+          <section>
+            <div><div>inline nested</div></div>
+          </section>
+          <a href="#">hyperlink</a>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+
+        expect(
+          result.document.children.every((child) =>
+            allowedChildren['root'].includes(child.type),
+          ),
+        ).toBeTruthy();
+
+        // The following is grouped in a single paragraph. I think it is fine.
+        // <strong>inline wrapped</strong>
+        // <section>
+        //   <div><div>inline nested</div></div>
+        // </section>
+        // <a href="#">hyperlink</a>
+        expect(result.document.children.map((child) => child.type))
+          .toMatchInlineSnapshot(`
+          Array [
+            "heading",
+            "paragraph",
+            "paragraph",
+            "blockquote",
+            "code",
+            "list",
+            "paragraph",
+          ]
+        `);
+      });
+    });
+
+    describe('paragraph', () => {
+      it('works', async () => {
+        const html = `
+          <p>simple paragraph</p>
+          <article>
+            <p>nested simple paragraph</p>
+          </article>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(result.document.children.map((child) => child.type))
+          .toMatchInlineSnapshot(`
+          Array [
+            "paragraph",
+            "paragraph",
+          ]
+        `);
+      });
+
+      it('generates valid children', async () => {
+        const html = `
+          <p>
+            <span>[simple text]</span>
+            <span>[span becomes simple text]</span>
+            <span>[span becomes simple text]</span>
+          </p>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(result.document.children).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "span",
+                  "value": "[simple text] ",
+                },
+                Object {
+                  "type": "span",
+                  "value": "[span becomes simple text]",
+                },
+                Object {
+                  "type": "span",
+                  "value": " ",
+                },
+                Object {
+                  "type": "span",
+                  "value": "[span becomes simple text]",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ]
+        `);
+      });
+    });
+
+    describe('heading', () => {
+      it('wraps children when necessary', async () => {
+        const html = `
+          <h1>needs wrapping</h1>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(result.document.children[0].type).toBe('heading');
+        expect(result.document.children[0].children[0].type).toBe('span');
+      });
+
+      it('allows link as children', async () => {
+        const html = `
+          <h1>span <a href="#">link</a></h1>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(result.document.children[0].children).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "type": "span",
+              "value": "span ",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "span",
+                  "value": "link",
+                },
+              ],
+              "type": "link",
+              "url": "#",
+            },
+          ]
+        `);
+      });
+
+      it('is converted to text when inside of another dast node (except root)', async () => {
+        const html = `
+          <section>
+            <ul>
+              <h1>inside ul</h1>
+            </ul>
+          </section>
+          <pre>
+            <code>
+              <h1>inside code</h1>
+            </code>
+          </pre>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(findAll(result.document, 'heading')).toHaveLength(0);
+      });
+
+      it('when not allowed produces paragraphs', async () => {
+        const html = `
+          <h1>dato</h1>
+        `;
+        const result = await richTextToStructuredText(html, {
+          allowedBlocks: [],
+        });
+        expect(validate(result).valid).toBeTruthy();
+        expect(findAll(result.document, 'heading')).toHaveLength(0);
+        expect(findAll(result.document, 'paragraph')).toHaveLength(1);
+        expect(find(result.document, 'span').value).toBe('dato');
+      });
+    });
+
+    describe('code', () => {
+      it('creates valid code node', async () => {
+        const html = `
+          <pre><code class="language-html"><span class="hljs-tag">&lt;<span class="hljs-name">import</span> <span class="hljs-attr">src</span>=<span class="hljs-string">"file.html"</span> /&gt;</span></code></pre>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(result.document.children[0]).toMatchInlineSnapshot(`
+          Object {
+            "code": "<import src=\\"file.html\\" />",
+            "language": "html",
+            "type": "code",
+          }
+        `);
+      });
+
+      it('when not allowed produces paragraphs', async () => {
+        const html = `
+          <code>let dato</code>
+        `;
+        const result = await richTextToStructuredText(html, {
+          allowedBlocks: [],
+        });
+        expect(validate(result).valid).toBeTruthy();
+        expect(findAll(result.document, 'code')).toHaveLength(0);
+        expect(findAll(result.document, 'paragraph')).toHaveLength(1);
+        expect(find(result.document, 'span').value).toBe('let dato');
+      });
+    });
+
+    describe('blockquote', () => {
+      it('creates valid blockquote node', async () => {
+        const html = `
+          <blockquote>1</blockquote>
+          <blockquote><span>2</span></blockquote>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(result.document.children.map((child) => child.type))
+          .toMatchInlineSnapshot(`
+          Array [
+            "blockquote",
+            "blockquote",
+          ]
+        `);
+        expect(result.document.children[0]).toMatchInlineSnapshot(`
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "type": "span",
+                    "value": "1",
+                  },
+                ],
+                "type": "paragraph",
+              },
+            ],
+            "type": "blockquote",
+          }
+        `);
+      });
+
+      it('when not allowed produces paragraphs', async () => {
+        const html = `
+          <blockquote>dato</blockquote>
+        `;
+        const result = await richTextToStructuredText(html, {
+          allowedBlocks: [],
+        });
+        expect(validate(result).valid).toBeTruthy();
+        expect(findAll(result.document, 'blockquote')).toHaveLength(0);
+        expect(findAll(result.document, 'paragraph')).toHaveLength(1);
+        expect(find(result.document, 'span').value).toBe('dato');
+      });
+    });
+
+    describe('list', () => {
+      it('creates valid list', async () => {
+        const html = `
+          <ul><li>test</li></ul>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(result.document.children[0].style).toBe('bulleted');
+      });
+
+      it('creates a numbered list from OL elements', async () => {
+        const html = `
+          <ol><li>test</li></ol>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(result.document.children[0].style).toBe('numbered');
+      });
+
+      it('supports nested lists', async () => {
+        const html = `
+          <ul>
+            <li><ul><li>1</li></ul></li>
+          </ul>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(find(find(result.document, 'list'), 'list')).toBeTruthy();
+      });
+
+      it('converts nested blockquote to text', async () => {
+        const html = `
+          <ul>
+            <li><blockquote>1</blockquote></li>
+          </ul>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(findAll(result.document, 'blockquote')).toHaveLength(0);
+        expect(find(result.document, 'span').value).toBe('1');
+      });
+
+      it('converts nested heading to text', async () => {
+        const html = `
+          <ul>
+            <li><h1>1</h1></li>
+          </ul>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(findAll(result.document, 'h1')).toHaveLength(0);
+        expect(find(result.document, 'span').value).toBe('1');
+      });
+
+      it('converts nested code to text', async () => {
+        const html = `
+          <ul>
+            <li><code>1</code></li>
+          </ul>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(findAll(result.document, 'code')).toHaveLength(0);
+        expect(find(result.document, 'span').value).toBe('1');
+      });
+
+      it('supports nested and/or unwrapped link', async () => {
+        const html = `
+          <ul>
+            <li><a href="#">1</a>2</li>
+            <a href="#">3</a>
+          </ul>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(findAll(result.document, 'link')).toHaveLength(2);
+        const items = findAll(result.document, 'listItem').map((listItem) =>
+          find(listItem, 'paragraph').children.map((child) => child.type),
+        );
+        expect(items).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              "link",
+              "span",
+            ],
+            Array [
+              "link",
+            ],
+          ]
+        `);
+      });
+
+      it('when not allowed produces paragraphs', async () => {
+        const html = `
+          <ul>
+            <li>dato</li>
+          </ul>
+        `;
+        const result = await richTextToStructuredText(html, {
+          allowedBlocks: [],
+        });
+        expect(validate(result).valid).toBeTruthy();
+        expect(findAll(result.document, 'list')).toHaveLength(0);
+        expect(findAll(result.document, 'paragraph')).toHaveLength(1);
+        expect(find(result.document, 'span').value).toBe('dato');
+      });
+    });
+
+    describe('thematicBreak', () => {
+      it('convert hr', async () => {
+        const html = `
+          <div>
+            <hr>
+            <blockquote>1<hr></blockquote>
+          </div>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        const thematicBreaks = findAll(result.document, 'thematicBreak');
+        expect(thematicBreaks).toHaveLength(1);
+      });
+    });
+
+    describe('link', () => {
+      // non credo che questo sia possibile con contentful
+      it('is wrapped when top level', async () => {
+        const html = `
+          <a href="#">1</a>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(result.document.children[0].type).toBe('paragraph');
+        expect(find(find(result.document, 'paragraph'), 'link')).toBeTruthy();
+      });
+
+      describe('when wrapping a heading', () => {
+        it('lifts up heading to contain the link', async () => {
+          const html = `
+            <a href="#"><h1>1</h1>2</a>
+          `;
+          const result = await richTextToStructuredText(html);
+          expect(validate(result).valid).toBeTruthy();
+          expect(result.document.children[0].type).toBe('heading');
+          expect(find(find(result.document, 'heading'), 'link')).toBeTruthy();
+          expect(find(find(result.document, 'paragraph'), 'link')).toBeTruthy();
+        });
+
+        it('ignores heading when it is not allowed in the context (eg. list)', async () => {
+          const html = `
+            <ul><a href="#"><h1>1</h1>2</a></ul>
+          `;
+          const result = await richTextToStructuredText(html);
+          expect(validate(result).valid).toBeTruthy();
+          expect(findAll(result.document, 'heading')).toHaveLength(0);
+        });
+      });
+
+      it('when not allowed produces paragraphs', async () => {
+        const html = `
+          <a href="#"><h1>dato</h1>2</a>
+        `;
+        const result = await richTextToStructuredText(html, {
+          allowedBlocks: [],
+        });
+        expect(validate(result).valid).toBeTruthy();
+        expect(findAll(result.document, 'link')).toHaveLength(0);
+        expect(findAll(result.document, 'heading')).toHaveLength(0);
+        expect(findAll(result.document, 'paragraph')).toHaveLength(1);
+        expect(find(result.document, 'span').value).toBe('dato');
+      });
+    });
+
+    describe('with Marks', () => {
+      const marksTags = {
+        bold: 'strong',
+        italic: 'emphasis',
+        underline: 'underline',
+        code: 'code',
+      };
+
+      describe('converts tags to marks', () => {
+        it.each(Object.keys(marksTags))(`%p`, async (tagName) => {
+          const markName = marksTags[tagName];
+          const html = `
+          <p><${tagName}>${markName}</${tagName}></p>
+        `;
+          const result = await richTextToStructuredText(html);
+          expect(validate(result).valid).toBeTruthy();
+          const span = find(result.document, 'span');
+          expect(span.marks).toBeTruthy();
+          expect(span.marks).toContain(markName);
+        });
+      });
+
+      describe('ignore mark tags when not in allowedMarks', () => {
+        it.each(Object.keys(marksTags))(`%p`, async (tagName) => {
+          const markName = marksTags[tagName];
+          const html = `
+          <p><${tagName}>${markName}</${tagName}></p>
+        `;
+          const result = await richTextToStructuredText(html, {
+            allowedMarks: [],
+          });
+          expect(validate(result).valid).toBeTruthy();
+          const span = find(result.document, 'span');
+          expect(span.marks).toBeFalsy();
+        });
+      });
+
+      it('collects marks when nesting nodes', async () => {
+        const html = `
+          <p><em>em<strong>strong-em<u>u-strong-em</u>strong-em</strong>em</em></p>
+        `;
+        const result = await richTextToStructuredText(html);
+        expect(validate(result).valid).toBeTruthy();
+        expect(
+          findAll(result.document, 'span')
+            .map(
+              (span) =>
+                `{ value: '${span.value}', marks: ['${span.marks.join(
+                  "', '",
+                )}'] }`,
+            )
+            .join('\n'),
+        ).toMatchInlineSnapshot(`
+          "{ value: 'em', marks: ['emphasis'] }
+          { value: 'strong-em', marks: ['emphasis', 'strong'] }
+          { value: 'u-strong-em', marks: ['emphasis', 'strong', 'underline'] }
+          { value: 'strong-em', marks: ['emphasis', 'strong'] }
+          { value: 'em', marks: ['emphasis'] }"
+        `);
+      });
+
+      describe('code', () => {
+        it('turns inline code tags to span with code mark', async () => {
+          const html = `
+            <p>To make it even easier to offer responsive, progressive images on your projects, we released a package called 
+            <a href="https://github.com/datocms/react-datocms">
+            <code>react-datocms</code></a> that exposes an <code>&lt;Image /&gt;</code> 
+            component and pairs perfectly with the <code>responsiveImage</code> query.
+            </p>`;
+          const result = await richTextToStructuredText(html);
+          expect(validate(result).valid).toBeTruthy();
+          expect(findAll(result.document, 'code')).toHaveLength(0);
+          const spans = findAll(result.document, 'span').filter(
+            (s) => Array.isArray(s.marks) && s.marks.includes('code'),
+          );
+          expect(spans).toHaveLength(3);
+          expect(spans.map((s) => s.value).join('\n')).toMatchInlineSnapshot(`
+            "react-datocms
+            <Image />
+            responsiveImage"
+          `);
+        });
+      });
+    });
   });
 });

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -1,0 +1,8 @@
+import { richTextToStructuredText } from '../src';
+
+describe('contentful-to-structured-text', () => {
+  it('needs tests', async () => {
+    const result = await richTextToStructuredText();
+    expect(result).toBeFalsy();
+  });
+});

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -221,9 +221,6 @@ describe('contentful-to-structured-text', () => {
       };
 
       const result = await richTextToStructuredText(richText);
-      console.log('[[[[[[[[[[[[[[[[[');
-      console.log(inspect(result, { depth: Infinity }));
-      console.log('[[[[[[[[[[[[[[[[[');
 
       expect(validate(result).valid).toBeTruthy();
       expect(result.document.children.map((child) => child.type))
@@ -235,42 +232,66 @@ describe('contentful-to-structured-text', () => {
         `);
     });
 
-    // it('generates valid children', async () => {
-    //   const richText = `
-    //       <p>
-    //         <span>[simple text]</span>
-    //         <span>[span becomes simple text]</span>
-    //         <span>[span becomes simple text]</span>
-    //       </p>
-    //     `;
-    //   const result = await richTextToStructuredText(richText);
-    //   expect(validate(result).valid).toBeTruthy();
-    //   expect(result.document.children).toMatchInlineSnapshot(`
-    //       Array [
-    //         Object {
-    //           "children": Array [
-    //             Object {
-    //               "type": "span",
-    //               "value": "[simple text] ",
-    //             },
-    //             Object {
-    //               "type": "span",
-    //               "value": "[span becomes simple text]",
-    //             },
-    //             Object {
-    //               "type": "span",
-    //               "value": " ",
-    //             },
-    //             Object {
-    //               "type": "span",
-    //               "value": "[span becomes simple text]",
-    //             },
-    //           ],
-    //           "type": "paragraph",
-    //         },
-    //       ]
-    //     `);
-    // });
+    it('generates valid children', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'paragraph',
+            content: [
+              { nodeType: 'text', value: '[span text] ', marks: [], data: {} },
+              {
+                nodeType: 'text',
+                value: '[span text]',
+                marks: ['bold', 'italic', 'underline', 'code', 'xxx'],
+                data: {},
+              },
+              {
+                nodeType: 'text',
+                value: '[strong text]',
+                marks: ['bold'],
+                data: {},
+              },
+            ],
+            data: {},
+          },
+        ],
+      };
+      const result = await richTextToStructuredText(richText);
+      console.log(inspect(result, { depth: Infinity }));
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "span",
+                  "value": "[span text] ",
+                },
+                Object {
+                  "marks": Array [
+                    "strong",
+                    "emphasis",
+                    "underline",
+                    "code",
+                  ],
+                  "type": "span",
+                  "value": "[span text]",
+                },
+                Object {
+                  "marks": Array [
+                    "strong",
+                  ],
+                  "type": "span",
+                  "value": "[strong text]",
+                },
+              ],
+              "type": "paragraph",
+            },
+          ]
+        `);
+    });
   });
 
   //   describe('heading', () => {

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -259,7 +259,6 @@ describe('contentful-to-structured-text', () => {
         ],
       };
       const result = await richTextToStructuredText(richText);
-      console.log(inspect(result, { depth: Infinity }));
       expect(validate(result).valid).toBeTruthy();
       expect(result.document.children).toMatchInlineSnapshot(`
           Array [
@@ -294,74 +293,92 @@ describe('contentful-to-structured-text', () => {
     });
   });
 
-  //   describe('heading', () => {
-  //     it('wraps children when necessary', async () => {
-  //       const richText = `
-  //         <h1>needs wrapping</h1>
-  //       `;
-  //       const result = await richTextToStructuredText(richText);
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(result.document.children[0].type).toBe('heading');
-  //       expect(result.document.children[0].children[0].type).toBe('span');
-  //     });
+  describe('heading', () => {
+    it('wraps children when necessary', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'heading-2',
+            content: [
+              {
+                nodeType: 'text',
+                value: 'Lorem ipsum dolor sit amet titolo',
+                marks: [],
+                data: {},
+              },
+            ],
+            data: {},
+          },
+        ],
+      };
 
-  //     it('allows link as children', async () => {
-  //       const richText = `
-  //         <h1>span <a href="#">link</a></h1>
-  //       `;
-  //       const result = await richTextToStructuredText(richText);
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(result.document.children[0].children).toMatchInlineSnapshot(`
-  //         Array [
-  //           Object {
-  //             "type": "span",
-  //             "value": "span ",
-  //           },
-  //           Object {
-  //             "children": Array [
-  //               Object {
-  //                 "type": "span",
-  //                 "value": "link",
-  //               },
-  //             ],
-  //             "type": "link",
-  //             "url": "#",
-  //           },
-  //         ]
-  //       `);
-  //     });
+      const result = await richTextToStructuredText(richText);
 
-  //     it('is converted to text when inside of another dast node (except root)', async () => {
-  //       const richText = `
-  //         <section>
-  //           <ul>
-  //             <h1>inside ul</h1>
-  //           </ul>
-  //         </section>
-  //         <pre>
-  //           <code>
-  //             <h1>inside code</h1>
-  //           </code>
-  //         </pre>
-  //       `;
-  //       const result = await richTextToStructuredText(richText);
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(findAll(result.document, 'heading')).toHaveLength(0);
-  //     });
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0].type).toBe('heading');
+      expect(result.document.children[0].level).toBe(2);
+      expect(result.document.children[0].children[0].type).toBe('span');
+    });
 
-  //     it('when not allowed produces paragraphs', async () => {
-  //       const richText = `
-  //         <h1>dato</h1>
-  //       `;
-  //       const result = await richTextToStructuredText(richText, {
-  //         allowedBlocks: [],
-  //       });
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(findAll(result.document, 'heading')).toHaveLength(0);
-  //       expect(findAll(result.document, 'paragraph')).toHaveLength(1);
-  //       expect(find(result.document, 'span').value).toBe('dato');
-  //     });
-  //   });
+    // it('allows link as children', async () => {
+    //   const richText = `
+    //       <h1>span <a href="#">link</a></h1>
+    //     `;
+    //   const result = await richTextToStructuredText(richText);
+    //   expect(validate(result).valid).toBeTruthy();
+    //   expect(result.document.children[0].children).toMatchInlineSnapshot(`
+    //       Array [
+    //         Object {
+    //           "type": "span",
+    //           "value": "span ",
+    //         },
+    //         Object {
+    //           "children": Array [
+    //             Object {
+    //               "type": "span",
+    //               "value": "link",
+    //             },
+    //           ],
+    //           "type": "link",
+    //           "url": "#",
+    //         },
+    //       ]
+    //     `);
+    // });
+
+    //     it('is converted to text when inside of another dast node (except root)', async () => {
+    //       const richText = `
+    //         <section>
+    //           <ul>
+    //             <h1>inside ul</h1>
+    //           </ul>
+    //         </section>
+    //         <pre>
+    //           <code>
+    //             <h1>inside code</h1>
+    //           </code>
+    //         </pre>
+    //       `;
+    //       const result = await richTextToStructuredText(richText);
+    //       expect(validate(result).valid).toBeTruthy();
+    //       expect(findAll(result.document, 'heading')).toHaveLength(0);
+    //     });
+
+    //     it('when not allowed produces paragraphs', async () => {
+    //       const richText = `
+    //         <h1>dato</h1>
+    //       `;
+    //       const result = await richTextToStructuredText(richText, {
+    //         allowedBlocks: [],
+    //       });
+    //       expect(validate(result).valid).toBeTruthy();
+    //       expect(findAll(result.document, 'heading')).toHaveLength(0);
+    //       expect(findAll(result.document, 'paragraph')).toHaveLength(1);
+    //       expect(find(result.document, 'span').value).toBe('dato');
+    //     });
+  });
 
   //   describe('code', () => {
   //     it('creates valid code node', async () => {

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -334,7 +334,7 @@ describe('contentful-to-structured-text', () => {
         data: {},
         content: [
           {
-            nodeType: 'heading-2',
+            nodeType: 'heading-3',
             content: [
               {
                 nodeType: 'text',
@@ -363,6 +363,8 @@ describe('contentful-to-structured-text', () => {
 
       const result = await richTextToStructuredText(richText);
       expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0].type).toBe('heading');
+      expect(result.document.children[0].level).toBe(3);
       expect(result.document.children[0].children).toMatchInlineSnapshot(`
         Array [
           Object {
@@ -396,15 +398,33 @@ describe('contentful-to-structured-text', () => {
         data: {},
         content: [
           {
-            nodeType: 'blockquote',
+            nodeType: 'unordered-list',
             content: [
               {
-                nodeType: 'paragraph',
+                nodeType: 'list-item',
                 content: [
                   {
-                    nodeType: 'text',
-                    value: 'This is heading',
-                    marks: [{ type: 'italic' }, { type: 'code' }],
+                    nodeType: 'heading-1',
+                    content: [
+                      {
+                        nodeType: 'text',
+                        value: 'This is heading ',
+                        marks: [{ type: 'code' }],
+                        data: {},
+                      },
+                      {
+                        nodeType: 'hyperlink',
+                        content: [
+                          {
+                            nodeType: 'text',
+                            value: 'foo',
+                            marks: [{ type: 'code' }],
+                            data: {},
+                          },
+                        ],
+                        data: { uri: 'https://loo.olll' },
+                      },
+                    ],
                     data: {},
                   },
                 ],
@@ -417,6 +437,7 @@ describe('contentful-to-structured-text', () => {
       };
 
       const result = await richTextToStructuredText(richText);
+
       expect(validate(result).valid).toBeTruthy();
       expect(result.document.children[0]).toMatchInlineSnapshot(`
         Object {
@@ -424,60 +445,78 @@ describe('contentful-to-structured-text', () => {
             Object {
               "children": Array [
                 Object {
-                  "marks": Array [
-                    "emphasis",
-                    "code",
+                  "children": Array [
+                    Object {
+                      "marks": Array [
+                        "code",
+                      ],
+                      "type": "span",
+                      "value": "This is heading ",
+                    },
+                    Object {
+                      "children": Array [
+                        Object {
+                          "marks": Array [
+                            "code",
+                          ],
+                          "type": "span",
+                          "value": "foo",
+                        },
+                      ],
+                      "type": "link",
+                      "url": "https://loo.olll",
+                    },
                   ],
-                  "type": "span",
-                  "value": "This is heading",
+                  "type": "paragraph",
                 },
               ],
-              "type": "paragraph",
+              "type": "listItem",
             },
           ],
-          "type": "blockquote",
+          "style": "bulleted",
+          "type": "list",
         }
       `);
     });
 
-    // it('when not allowed produces paragraphs', async () => {
-    //   const richText = `
-    //         <h1>dato</h1>
-    //       `;
-    //   const result = await richTextToStructuredText(richText, {
-    //     allowedBlocks: [],
-    //   });
-    // console.log(inspect(result, { depth: Infinity }));
+    it('when not allowed produces paragraphs', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'heading-2',
+            content: [
+              {
+                nodeType: 'text',
+                value: 'This is heading',
+                marks: [{ type: 'italic' }],
+                data: {},
+              },
+            ],
+            data: {},
+          },
+        ],
+      };
 
-    //   expect(validate(result).valid).toBeTruthy();
-    //   expect(result.document.children[0].children).toMatchInlineSnapshot(`
-    //       Array [
-    //         Object {
-    //           "marks": Array [
-    //             "emphasis",
-    //           ],
-    //           "type": "span",
-    //           "value": "This is heading ",
-    //         },
-    //         Object {
-    //           "children": Array [
-    //             Object {
-    //               "type": "span",
-    //               "value": "link",
-    //             },
-    //           ],
-    //           "type": "link",
-    //           "url": "https://fooo.com",
-    //         },
-    //         Object {
-    //           "type": "span",
-    //           "value": "!",
-    //         },
-    //       ]
-    //     `);
-    //   expect(findAll(result.document, 'paragraph')).toHaveLength(1);
-    //   expect(find(result.document, 'span').value).toBe('dato');
-    // });
+      const result = await richTextToStructuredText(richText, {
+        allowedBlocks: [],
+      });
+
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0].children).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "marks": Array [
+                "emphasis",
+              ],
+              "type": "span",
+              "value": "This is heading",
+            },
+          ]
+        `);
+      expect(result.document.children[0].type).toBe('paragraph');
+    });
   });
 
   //   describe('code', () => {

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -244,13 +244,19 @@ describe('contentful-to-structured-text', () => {
               {
                 nodeType: 'text',
                 value: '[span text]',
-                marks: ['bold', 'italic', 'underline', 'code', 'xxx'],
+                marks: [
+                  { type: 'bold' },
+                  { type: 'italic' },
+                  { type: 'underline' },
+                  { type: 'code' },
+                  { type: 'xxx' },
+                ],
                 data: {},
               },
               {
                 nodeType: 'text',
                 value: '[strong text]',
-                marks: ['bold'],
+                marks: [{ type: 'bold' }],
                 data: {},
               },
             ],
@@ -333,7 +339,7 @@ describe('contentful-to-structured-text', () => {
               {
                 nodeType: 'text',
                 value: 'This is heading ',
-                marks: ['italic'],
+                marks: [{ type: 'italic' }],
                 data: {},
               },
               {
@@ -356,66 +362,122 @@ describe('contentful-to-structured-text', () => {
       };
 
       const result = await richTextToStructuredText(richText);
-      console.log(inspect(result, { depth: Infinity }));
-
       expect(validate(result).valid).toBeTruthy();
       expect(result.document.children[0].children).toMatchInlineSnapshot(`
-          Array [
-            Object {
-              "marks": Array [
-                "emphasis",
-              ],
-              "type": "span",
-              "value": "This is heading ",
-            },
+        Array [
+          Object {
+            "marks": Array [
+              "emphasis",
+            ],
+            "type": "span",
+            "value": "This is heading ",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "type": "span",
+                "value": "link",
+              },
+            ],
+            "type": "link",
+            "url": "https://fooo.com",
+          },
+          Object {
+            "type": "span",
+            "value": "!",
+          },
+        ]
+      `);
+    });
+
+    it('is converted to text when inside of another node (except root)', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'blockquote',
+            content: [
+              {
+                nodeType: 'paragraph',
+                content: [
+                  {
+                    nodeType: 'text',
+                    value: 'This is heading',
+                    marks: [{ type: 'italic' }, { type: 'code' }],
+                    data: {},
+                  },
+                ],
+                data: {},
+              },
+            ],
+            data: {},
+          },
+        ],
+      };
+
+      const result = await richTextToStructuredText(richText);
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0]).toMatchInlineSnapshot(`
+        Object {
+          "children": Array [
             Object {
               "children": Array [
                 Object {
+                  "marks": Array [
+                    "emphasis",
+                    "code",
+                  ],
                   "type": "span",
-                  "value": "link",
+                  "value": "This is heading",
                 },
               ],
-              "type": "link",
-              "url": "https://fooo.com",
+              "type": "paragraph",
             },
-            Object {
-              "type": "span",
-              "value": "!",
-            },
-          ]
-        `);
+          ],
+          "type": "blockquote",
+        }
+      `);
     });
 
-    //     it('is converted to text when inside of another dast node (except root)', async () => {
-    //       const richText = `
-    //         <section>
-    //           <ul>
-    //             <h1>inside ul</h1>
-    //           </ul>
-    //         </section>
-    //         <pre>
-    //           <code>
-    //             <h1>inside code</h1>
-    //           </code>
-    //         </pre>
-    //       `;
-    //       const result = await richTextToStructuredText(richText);
-    //       expect(validate(result).valid).toBeTruthy();
-    //       expect(findAll(result.document, 'heading')).toHaveLength(0);
-    //     });
-
-    //     it('when not allowed produces paragraphs', async () => {
-    //       const richText = `
+    // it('when not allowed produces paragraphs', async () => {
+    //   const richText = `
     //         <h1>dato</h1>
     //       `;
-    //       const result = await richTextToStructuredText(richText, {
-    //         allowedBlocks: [],
-    //       });
-    //       expect(validate(result).valid).toBeTruthy();
-    //       expect(findAll(result.document, 'heading')).toHaveLength(0);
-    //       expect(findAll(result.document, 'paragraph')).toHaveLength(1);
-    //       expect(find(result.document, 'span').value).toBe('dato');
-    //     });
+    //   const result = await richTextToStructuredText(richText, {
+    //     allowedBlocks: [],
+    //   });
+    // console.log(inspect(result, { depth: Infinity }));
+
+    //   expect(validate(result).valid).toBeTruthy();
+    //   expect(result.document.children[0].children).toMatchInlineSnapshot(`
+    //       Array [
+    //         Object {
+    //           "marks": Array [
+    //             "emphasis",
+    //           ],
+    //           "type": "span",
+    //           "value": "This is heading ",
+    //         },
+    //         Object {
+    //           "children": Array [
+    //             Object {
+    //               "type": "span",
+    //               "value": "link",
+    //             },
+    //           ],
+    //           "type": "link",
+    //           "url": "https://fooo.com",
+    //         },
+    //         Object {
+    //           "type": "span",
+    //           "value": "!",
+    //         },
+    //       ]
+    //     `);
+    //   expect(findAll(result.document, 'paragraph')).toHaveLength(1);
+    //   expect(find(result.document, 'span').value).toBe('dato');
+    // });
   });
 
   //   describe('code', () => {

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -659,30 +659,30 @@ describe('contentful-to-structured-text', () => {
 
         expect(validate(result).valid).toBeTruthy();
         expect(result.document.children[0]).toMatchInlineSnapshot(`
-        Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "marks": Array [
-                        "code",
-                      ],
-                      "type": "span",
-                      "value": "<import src=\\"file.richText\\" />",
-                    },
-                  ],
-                  "type": "paragraph",
-                },
-              ],
-              "type": "listItem",
-            },
-          ],
-          "style": "bulleted",
-          "type": "list",
-        }
-      `);
+                  Object {
+                    "children": Array [
+                      Object {
+                        "children": Array [
+                          Object {
+                            "children": Array [
+                              Object {
+                                "marks": Array [
+                                  "code",
+                                ],
+                                "type": "span",
+                                "value": "<import src=\\"file.richText\\" />",
+                              },
+                            ],
+                            "type": "paragraph",
+                          },
+                        ],
+                        "type": "listItem",
+                      },
+                    ],
+                    "style": "bulleted",
+                    "type": "list",
+                  }
+              `);
       });
 
       it('when code mark is not allowed it generates simple paragraphs', async () => {
@@ -830,7 +830,7 @@ describe('contentful-to-structured-text', () => {
                 nodeType: 'list-item',
                 content: [
                   {
-                    nodeType: 'heading-1',
+                    nodeType: 'paragraph',
                     content: [
                       {
                         nodeType: 'text',
@@ -1418,6 +1418,187 @@ describe('contentful-to-structured-text', () => {
           ]
         `);
       });
+    });
+  });
+
+  describe('wrap', () => {
+    it('wraps all in paragraph', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'unordered-list',
+            content: [
+              {
+                nodeType: 'list-item',
+                content: [
+                  {
+                    nodeType: 'heading-1',
+                    content: [
+                      {
+                        nodeType: 'text',
+                        value: 'span',
+                        marks: [],
+                        data: {},
+                      },
+                      {
+                        nodeType: 'text',
+                        value: ', other span',
+                        marks: [],
+                        data: {},
+                      },
+                      {
+                        nodeType: 'hyperlink',
+                        content: [
+                          {
+                            nodeType: 'text',
+                            value: 'link',
+                            marks: [],
+                            data: {},
+                          },
+                        ],
+                        data: { uri: 'https://fooo.com' },
+                      },
+                      {
+                        nodeType: 'blockquote',
+                        content: [
+                          {
+                            nodeType: 'paragraph',
+                            content: [
+                              {
+                                nodeType: 'text',
+                                value: 'quote',
+                                marks: [],
+                                data: {},
+                              },
+                            ],
+                            data: {},
+                          },
+                        ],
+                        data: {},
+                      },
+                    ],
+                    data: {},
+                  },
+                ],
+                data: {},
+              },
+            ],
+            data: {},
+          },
+        ],
+      };
+
+      const result = await richTextToStructuredText(richText);
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "type": "span",
+                        "value": "span",
+                      },
+                      Object {
+                        "type": "span",
+                        "value": ", other span",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "type": "span",
+                            "value": "link",
+                          },
+                        ],
+                        "type": "link",
+                        "url": "https://fooo.com",
+                      },
+                    ],
+                    "type": "paragraph",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "type": "span",
+                        "value": "quote",
+                      },
+                    ],
+                    "type": "paragraph",
+                  },
+                ],
+                "type": "listItem",
+              },
+            ],
+            "style": "bulleted",
+            "type": "list",
+          },
+        ]
+      `);
+    });
+
+    it('always returns something, even with empty text', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'unordered-list',
+            content: [
+              {
+                nodeType: 'list-item',
+                content: [
+                  {
+                    nodeType: 'heading-1',
+                    content: [
+                      {
+                        nodeType: 'text',
+                        value: ' ',
+                        marks: [],
+                        data: {},
+                      },
+                    ],
+                    data: {},
+                  },
+                ],
+                data: {},
+              },
+            ],
+            data: {},
+          },
+        ],
+      };
+
+      const result = await richTextToStructuredText(richText);
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "type": "span",
+                        "value": " ",
+                      },
+                    ],
+                    "type": "paragraph",
+                  },
+                ],
+                "type": "listItem",
+              },
+            ],
+            "style": "bulleted",
+            "type": "list",
+          },
+        ]
+      `);
     });
   });
 });

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -1114,54 +1114,115 @@ describe('contentful-to-structured-text', () => {
     });
   });
 
-  //   describe('link', () => {
-  //     // non credo che questo sia possibile con contentful
-  //     it('is wrapped when top level', async () => {
-  //       const richText = `
-  //         <a href="#">1</a>
-  //       `;
-  //       const result = await richTextToStructuredText(richText);
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(result.document.children[0].type).toBe('paragraph');
-  //       expect(find(find(result.document, 'paragraph'), 'link')).toBeTruthy();
-  //     });
+  describe('link', () => {
+    describe('when wrapping a heading', () => {
+      it('lifts up heading to contain the link', async () => {
+        const richText = {
+          nodeType: 'document',
+          data: {},
+          content: [
+            {
+              nodeType: 'heading-1',
+              content: [
+                {
+                  nodeType: 'hyperlink',
+                  content: [
+                    {
+                      nodeType: 'text',
+                      value: 'link',
+                      marks: [],
+                      data: {},
+                    },
+                  ],
+                  data: { uri: 'https://foo.bar' },
+                },
+              ],
+              data: {},
+            },
+          ],
+        };
 
-  //     describe('when wrapping a heading', () => {
-  //       it('lifts up heading to contain the link', async () => {
-  //         const richText = `
-  //           <a href="#"><h1>1</h1>2</a>
-  //         `;
-  //         const result = await richTextToStructuredText(richText);
-  //         expect(validate(result).valid).toBeTruthy();
-  //         expect(result.document.children[0].type).toBe('heading');
-  //         expect(find(find(result.document, 'heading'), 'link')).toBeTruthy();
-  //         expect(find(find(result.document, 'paragraph'), 'link')).toBeTruthy();
-  //       });
+        const result = await richTextToStructuredText(richText);
+        expect(validate(result).valid).toBeTruthy();
+        expect(result.document.children[0].type).toBe('heading');
+        expect(result.document.children[0].children[0]).toMatchInlineSnapshot(`
+            Object {
+              "children": Array [
+                Object {
+                  "type": "span",
+                  "value": "link",
+                },
+              ],
+              "type": "link",
+              "url": "https://foo.bar",
+            }
+        `);
+      });
 
-  //       it('ignores heading when it is not allowed in the context (eg. list)', async () => {
-  //         const richText = `
-  //           <ul><a href="#"><h1>1</h1>2</a></ul>
-  //         `;
-  //         const result = await richTextToStructuredText(richText);
-  //         expect(validate(result).valid).toBeTruthy();
-  //         expect(findAll(result.document, 'heading')).toHaveLength(0);
-  //       });
-  //     });
-
-  //     it('when not allowed produces paragraphs', async () => {
-  //       const richText = `
-  //         <a href="#"><h1>dato</h1>2</a>
-  //       `;
-  //       const result = await richTextToStructuredText(richText, {
-  //         allowedBlocks: [],
-  //       });
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(findAll(result.document, 'link')).toHaveLength(0);
-  //       expect(findAll(result.document, 'heading')).toHaveLength(0);
-  //       expect(findAll(result.document, 'paragraph')).toHaveLength(1);
-  //       expect(find(result.document, 'span').value).toBe('dato');
-  //     });
-  //   });
+      it('ignores heading when it is not allowed in the context (eg. list)', async () => {
+        const richText = {
+          nodeType: 'document',
+          data: {},
+          content: [
+            {
+              nodeType: 'unordered-list',
+              content: [
+                {
+                  nodeType: 'list-item',
+                  content: [
+                    {
+                      nodeType: 'heading-1',
+                      content: [
+                        {
+                          nodeType: 'hyperlink',
+                          content: [
+                            {
+                              nodeType: 'text',
+                              value: 'link',
+                              marks: [],
+                              data: {},
+                            },
+                          ],
+                          data: { uri: 'https://foo.bar' },
+                        },
+                      ],
+                      data: {},
+                    },
+                  ],
+                  data: {},
+                },
+              ],
+              data: {},
+            },
+          ],
+        };
+        const result = await richTextToStructuredText(richText);
+        expect(validate(result).valid).toBeTruthy();
+        expect(result.document.children[0].children[0]).toMatchInlineSnapshot(`
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "type": "span",
+                          "value": "link",
+                        },
+                      ],
+                      "type": "link",
+                      "url": "https://foo.bar",
+                    },
+                  ],
+                  "type": "paragraph",
+                },
+              ],
+              "type": "listItem",
+            }
+        `);
+      });
+    });
+  });
 
   //   describe('with Marks', () => {
   //     const marksTags = {

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -643,7 +643,6 @@ describe('contentful-to-structured-text', () => {
 
     it('creates valid blockquote node', async () => {
       const result = await richTextToStructuredText(richText);
-      console.log(inspect(result, { depth: Infinity }));
 
       expect(validate(result).valid).toBeTruthy();
       expect(result.document.children.map((child) => child.type))
@@ -692,113 +691,404 @@ describe('contentful-to-structured-text', () => {
     });
   });
 
-  //   describe('list', () => {
-  //     it('creates valid list', async () => {
-  //       const richText = `
-  //         <ul><li>test</li></ul>
-  //       `;
-  //       const result = await richTextToStructuredText(richText);
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(result.document.children[0].style).toBe('bulleted');
-  //     });
+  describe('list', () => {
+    it('creates valid list', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'unordered-list',
+            content: [
+              {
+                nodeType: 'list-item',
+                content: [
+                  {
+                    nodeType: 'paragraph',
+                    content: [
+                      {
+                        nodeType: 'text',
+                        value: 'Foo',
+                        marks: [{ type: 'underline' }],
+                        data: {},
+                      },
+                    ],
+                    data: {},
+                  },
+                ],
+                data: {},
+              },
+              {
+                nodeType: 'list-item',
+                content: [
+                  {
+                    nodeType: 'heading-1',
+                    content: [
+                      {
+                        nodeType: 'text',
+                        value: 'Bar',
+                        marks: [{ type: 'code' }],
+                        data: {},
+                      },
+                    ],
+                    data: {},
+                  },
+                ],
+                data: {},
+              },
+            ],
+            data: {},
+          },
+        ],
+      };
+      const result = await richTextToStructuredText(richText);
 
-  //     it('creates a numbered list from OL elements', async () => {
-  //       const richText = `
-  //         <ol><li>test</li></ol>
-  //       `;
-  //       const result = await richTextToStructuredText(richText);
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(result.document.children[0].style).toBe('numbered');
-  //     });
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0].style).toBe('bulleted');
+      expect(result.document.children).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "children": Array [
+                          Object {
+                            "marks": Array [
+                              "underline",
+                            ],
+                            "type": "span",
+                            "value": "Foo",
+                          },
+                        ],
+                        "type": "paragraph",
+                      },
+                    ],
+                    "type": "listItem",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "children": Array [
+                          Object {
+                            "marks": Array [
+                              "code",
+                            ],
+                            "type": "span",
+                            "value": "Bar",
+                          },
+                        ],
+                        "type": "paragraph",
+                      },
+                    ],
+                    "type": "listItem",
+                  },
+                ],
+                "style": "bulleted",
+                "type": "list",
+              },
+            ]
+          `);
+    });
 
-  //     it('supports nested lists', async () => {
-  //       const richText = `
-  //         <ul>
-  //           <li><ul><li>1</li></ul></li>
-  //         </ul>
-  //       `;
-  //       const result = await richTextToStructuredText(richText);
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(find(find(result.document, 'list'), 'list')).toBeTruthy();
-  //     });
+    it('creates a numbered list from OL elements', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'ordered-list',
+            content: [
+              {
+                nodeType: 'list-item',
+                content: [
+                  {
+                    nodeType: 'paragraph',
+                    content: [
+                      {
+                        nodeType: 'text',
+                        value: 'Foo',
+                        marks: [],
+                        data: {},
+                      },
+                    ],
+                    data: {},
+                  },
+                ],
+                data: {},
+              },
+            ],
+            data: {},
+          },
+        ],
+      };
 
-  //     it('converts nested blockquote to text', async () => {
-  //       const richText = `
-  //         <ul>
-  //           <li><blockquote>1</blockquote></li>
-  //         </ul>
-  //       `;
-  //       const result = await richTextToStructuredText(richText);
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(findAll(result.document, 'blockquote')).toHaveLength(0);
-  //       expect(find(result.document, 'span').value).toBe('1');
-  //     });
+      const result = await richTextToStructuredText(richText);
 
-  //     it('converts nested heading to text', async () => {
-  //       const richText = `
-  //         <ul>
-  //           <li><h1>1</h1></li>
-  //         </ul>
-  //       `;
-  //       const result = await richTextToStructuredText(richText);
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(findAll(result.document, 'h1')).toHaveLength(0);
-  //       expect(find(result.document, 'span').value).toBe('1');
-  //     });
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0].style).toBe('numbered');
+    });
 
-  //     it('converts nested code to text', async () => {
-  //       const richText = `
-  //         <ul>
-  //           <li><code>1</code></li>
-  //         </ul>
-  //       `;
-  //       const result = await richTextToStructuredText(richText);
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(findAll(result.document, 'code')).toHaveLength(0);
-  //       expect(find(result.document, 'span').value).toBe('1');
-  //     });
+    it('supports nested lists', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'unordered-list',
+            content: [
+              {
+                nodeType: 'list-item',
+                content: [
+                  {
+                    nodeType: 'paragraph',
+                    content: [
+                      {
+                        nodeType: 'text',
+                        value: 'foo',
+                        marks: [],
+                        data: {},
+                      },
+                    ],
+                    data: {},
+                  },
+                  {
+                    nodeType: 'unordered-list',
+                    content: [
+                      {
+                        nodeType: 'list-item',
+                        content: [
+                          {
+                            nodeType: 'paragraph',
+                            content: [
+                              {
+                                nodeType: 'text',
+                                value: 'bar',
+                                marks: [],
+                                data: {},
+                              },
+                            ],
+                            data: {},
+                          },
+                        ],
+                        data: {},
+                      },
+                    ],
+                    data: {},
+                  },
+                ],
+                data: {},
+              },
+            ],
+            data: {},
+          },
+        ],
+      };
 
-  //     it('supports nested and/or unwrapped link', async () => {
-  //       const richText = `
-  //         <ul>
-  //           <li><a href="#">1</a>2</li>
-  //           <a href="#">3</a>
-  //         </ul>
-  //       `;
-  //       const result = await richTextToStructuredText(richText);
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(findAll(result.document, 'link')).toHaveLength(2);
-  //       const items = findAll(result.document, 'listItem').map((listItem) =>
-  //         find(listItem, 'paragraph').children.map((child) => child.type),
-  //       );
-  //       expect(items).toMatchInlineSnapshot(`
-  //         Array [
-  //           Array [
-  //             "link",
-  //             "span",
-  //           ],
-  //           Array [
-  //             "link",
-  //           ],
-  //         ]
-  //       `);
-  //     });
+      const result = await richTextToStructuredText(richText);
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0].children[0].children[1].type).toBe(
+        'list',
+      );
+    });
 
-  //     it('when not allowed produces paragraphs', async () => {
-  //       const richText = `
-  //         <ul>
-  //           <li>dato</li>
-  //         </ul>
-  //       `;
-  //       const result = await richTextToStructuredText(richText, {
-  //         allowedBlocks: [],
-  //       });
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(findAll(result.document, 'list')).toHaveLength(0);
-  //       expect(findAll(result.document, 'paragraph')).toHaveLength(1);
-  //       expect(find(result.document, 'span').value).toBe('dato');
-  //     });
-  //   });
+    it('converts nested blockquote to text', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'unordered-list',
+            content: [
+              {
+                nodeType: 'list-item',
+                content: [
+                  {
+                    nodeType: 'blockquote',
+                    content: [
+                      {
+                        nodeType: 'paragraph',
+                        content: [
+                          {
+                            nodeType: 'text',
+                            value: 'quote',
+                            marks: [],
+                            data: {},
+                          },
+                        ],
+                        data: {},
+                      },
+                    ],
+                    data: {},
+                  },
+                ],
+                data: {},
+              },
+            ],
+            data: {},
+          },
+        ],
+      };
+
+      const result = await richTextToStructuredText(richText);
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0].children[0].children[0].type).toBe(
+        'paragraph',
+      );
+    });
+
+    it('converts nested heading to text', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'unordered-list',
+            content: [
+              {
+                nodeType: 'list-item',
+                content: [
+                  {
+                    nodeType: 'heading-2',
+                    content: [
+                      {
+                        nodeType: 'paragraph',
+                        content: [
+                          {
+                            nodeType: 'text',
+                            value: 'heading',
+                            marks: [],
+                            data: {},
+                          },
+                        ],
+                        data: {},
+                      },
+                    ],
+                    data: {},
+                  },
+                ],
+                data: {},
+              },
+            ],
+            data: {},
+          },
+        ],
+      };
+
+      const result = await richTextToStructuredText(richText);
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0].children[0].children[0].type).toBe(
+        'paragraph',
+      );
+    });
+
+    it('supports link', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'unordered-list',
+            content: [
+              {
+                nodeType: 'list-item',
+                content: [
+                  {
+                    nodeType: 'paragraph',
+                    content: [
+                      {
+                        nodeType: 'hyperlink',
+                        content: [
+                          {
+                            nodeType: 'text',
+                            value: 'link',
+                            marks: [],
+                            data: {},
+                          },
+                        ],
+                        data: { uri: 'https://foo.bar' },
+                      },
+                    ],
+                    data: {},
+                  },
+                ],
+                data: {},
+              },
+            ],
+            data: {},
+          },
+        ],
+      };
+      const result = await richTextToStructuredText(richText);
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0].children[0].children[0].type).toBe(
+        'paragraph',
+      );
+      expect(
+        result.document.children[0].children[0].children[0].children[0].type,
+      ).toBe('link');
+      expect(result.document.children[0].children[0]).toMatchInlineSnapshot(`
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "type": "span",
+                        "value": "link",
+                      },
+                    ],
+                    "type": "link",
+                    "url": "https://foo.bar",
+                  },
+                ],
+                "type": "paragraph",
+              },
+            ],
+            "type": "listItem",
+          }
+        `);
+    });
+
+    it('when not allowed produces paragraphs', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'unordered-list',
+            content: [
+              {
+                nodeType: 'list-item',
+                content: [
+                  {
+                    nodeType: 'paragraph',
+                    content: [
+                      {
+                        nodeType: 'text',
+                        value: 'Foo',
+                        marks: [],
+                        data: {},
+                      },
+                    ],
+                    data: {},
+                  },
+                ],
+                data: {},
+              },
+            ],
+            data: {},
+          },
+        ],
+      };
+      const result = await richTextToStructuredText(richText, {
+        allowedBlocks: [],
+      });
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0].type).toBe('paragraph');
+    });
+  });
 
   //   describe('thematicBreak', () => {
   //     it('convert hr', async () => {

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -1090,20 +1090,29 @@ describe('contentful-to-structured-text', () => {
     });
   });
 
-  //   describe('thematicBreak', () => {
-  //     it('convert hr', async () => {
-  //       const richText = `
-  //         <div>
-  //           <hr>
-  //           <blockquote>1<hr></blockquote>
-  //         </div>
-  //       `;
-  //       const result = await richTextToStructuredText(richText);
-  //       expect(validate(result).valid).toBeTruthy();
-  //       const thematicBreaks = findAll(result.document, 'thematicBreak');
-  //       expect(thematicBreaks).toHaveLength(1);
-  //     });
-  //   });
+  describe('thematicBreak', () => {
+    it('convert hr', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'hr',
+            content: [],
+            data: {},
+          },
+        ],
+      };
+      const result = await richTextToStructuredText(richText);
+      console.log(inspect(result, { depth: Infinity }));
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0]).toMatchInlineSnapshot(`
+        Object {
+          "type": "thematicBreak",
+        }
+      `);
+    });
+  });
 
   //   describe('link', () => {
   //     // non credo che questo sia possibile con contentful

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -5,13 +5,20 @@ import { richTextToStructuredText, datoToContentfulMarks } from '../src';
 import { allowedChildren, validate } from 'datocms-structured-text-utils';
 
 describe('contentful-to-structured-text', () => {
-  it('works with empty document', async () => {
+  it('works with empty rich text', async () => {
     const richText = {
       nodeType: 'document',
       data: {},
       content: [],
     };
 
+    const result = await richTextToStructuredText(richText);
+    expect(validate(result).valid).toBeTruthy();
+    expect(result).toMatchInlineSnapshot(`null`);
+  });
+
+  it('works when null value is passed', async () => {
+    const richText = null;
     const result = await richTextToStructuredText(richText);
     expect(validate(result).valid).toBeTruthy();
     expect(result).toMatchInlineSnapshot(`null`);

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -322,31 +322,69 @@ describe('contentful-to-structured-text', () => {
       expect(result.document.children[0].children[0].type).toBe('span');
     });
 
-    // it('allows link as children', async () => {
-    //   const richText = `
-    //       <h1>span <a href="#">link</a></h1>
-    //     `;
-    //   const result = await richTextToStructuredText(richText);
-    //   expect(validate(result).valid).toBeTruthy();
-    //   expect(result.document.children[0].children).toMatchInlineSnapshot(`
-    //       Array [
-    //         Object {
-    //           "type": "span",
-    //           "value": "span ",
-    //         },
-    //         Object {
-    //           "children": Array [
-    //             Object {
-    //               "type": "span",
-    //               "value": "link",
-    //             },
-    //           ],
-    //           "type": "link",
-    //           "url": "#",
-    //         },
-    //       ]
-    //     `);
-    // });
+    it('allows link as children', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'heading-2',
+            content: [
+              {
+                nodeType: 'text',
+                value: 'This is heading ',
+                marks: ['italic'],
+                data: {},
+              },
+              {
+                nodeType: 'hyperlink',
+                content: [
+                  {
+                    nodeType: 'text',
+                    value: 'link',
+                    marks: [],
+                    data: {},
+                  },
+                ],
+                data: { uri: 'https://fooo.com' },
+              },
+              { nodeType: 'text', value: '!', marks: [], data: {} },
+            ],
+            data: {},
+          },
+        ],
+      };
+
+      const result = await richTextToStructuredText(richText);
+      console.log(inspect(result, { depth: Infinity }));
+
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0].children).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "marks": Array [
+                "emphasis",
+              ],
+              "type": "span",
+              "value": "This is heading ",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "span",
+                  "value": "link",
+                },
+              ],
+              "type": "link",
+              "url": "https://fooo.com",
+            },
+            Object {
+              "type": "span",
+              "value": "!",
+            },
+          ]
+        `);
+    });
 
     //     it('is converted to text when inside of another dast node (except root)', async () => {
     //       const richText = `

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -609,52 +609,88 @@ describe('contentful-to-structured-text', () => {
     });
   });
 
-  //   describe('blockquote', () => {
-  //     it('creates valid blockquote node', async () => {
-  //       const richText = `
-  //         <blockquote>1</blockquote>
-  //         <blockquote><span>2</span></blockquote>
-  //       `;
-  //       const result = await richTextToStructuredText(richText);
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(result.document.children.map((child) => child.type))
-  //         .toMatchInlineSnapshot(`
-  //         Array [
-  //           "blockquote",
-  //           "blockquote",
-  //         ]
-  //       `);
-  //       expect(result.document.children[0]).toMatchInlineSnapshot(`
-  //         Object {
-  //           "children": Array [
-  //             Object {
-  //               "children": Array [
-  //                 Object {
-  //                   "type": "span",
-  //                   "value": "1",
-  //                 },
-  //               ],
-  //               "type": "paragraph",
-  //             },
-  //           ],
-  //           "type": "blockquote",
-  //         }
-  //       `);
-  //     });
+  describe('blockquote', () => {
+    const richText = {
+      nodeType: 'document',
+      data: {},
+      content: [
+        {
+          nodeType: 'blockquote',
+          content: [
+            {
+              nodeType: 'paragraph',
+              content: [
+                {
+                  nodeType: 'text',
+                  value: 'foo',
+                  marks: [{ type: 'code' }, { type: 'italic' }],
+                  data: {},
+                },
+                {
+                  nodeType: 'text',
+                  value: 'bar',
+                  marks: [{ type: 'code' }, { type: 'bold' }],
+                  data: {},
+                },
+              ],
+              data: {},
+            },
+          ],
+          data: {},
+        },
+      ],
+    };
 
-  //     it('when not allowed produces paragraphs', async () => {
-  //       const richText = `
-  //         <blockquote>dato</blockquote>
-  //       `;
-  //       const result = await richTextToStructuredText(richText, {
-  //         allowedBlocks: [],
-  //       });
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(findAll(result.document, 'blockquote')).toHaveLength(0);
-  //       expect(findAll(result.document, 'paragraph')).toHaveLength(1);
-  //       expect(find(result.document, 'span').value).toBe('dato');
-  //     });
-  //   });
+    it('creates valid blockquote node', async () => {
+      const result = await richTextToStructuredText(richText);
+      console.log(inspect(result, { depth: Infinity }));
+
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children.map((child) => child.type))
+        .toMatchInlineSnapshot(`
+          Array [
+            "blockquote",
+          ]
+        `);
+      expect(result.document.children[0]).toMatchInlineSnapshot(`
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "marks": Array [
+                      "code",
+                      "emphasis",
+                    ],
+                    "type": "span",
+                    "value": "foo",
+                  },
+                  Object {
+                    "marks": Array [
+                      "code",
+                      "strong",
+                    ],
+                    "type": "span",
+                    "value": "bar",
+                  },
+                ],
+                "type": "paragraph",
+              },
+            ],
+            "type": "blockquote",
+          }
+        `);
+    });
+
+    it('when not allowed produces paragraphs', async () => {
+      const result = await richTextToStructuredText(richText, {
+        allowedBlocks: [],
+      });
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0].type).toBe('paragraph');
+      expect(result.document.children[0].children[0].value).toBe('foo');
+    });
+  });
 
   //   describe('list', () => {
   //     it('creates valid list', async () => {

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -6,26 +6,31 @@ import { allowedChildren, Span, validate } from 'datocms-structured-text-utils';
 
 describe('contentful-to-structured-text', () => {
   it('works with empty document', async () => {
-    const html = '';
-    const result = await richTextToStructuredText(html);
+    const richText = {
+      nodeType: 'document',
+      data: {},
+      content: [],
+    };
+
+    const result = await richTextToStructuredText(richText);
     expect(validate(result).valid).toBeTruthy();
     expect(result).toMatchInlineSnapshot(`null`);
   });
 
   it('rejects invalid rich text documents', async () => {
-    const html = '';
-    const result = await richTextToStructuredText(html);
+    const richText = '';
+    const result = await richTextToStructuredText(richText);
     expect(validate(result).valid).toBeTruthy();
     expect(result).toMatchInlineSnapshot(`null`);
   });
 
   describe('handlers', () => {
     it('can return an array of nodes', async () => {
-      const html = `
+      const richText = `
         <p>twice</p>
       `;
 
-      const result = await richTextToStructuredText(html, {
+      const result = await richTextToStructuredText(richText, {
         handlers: {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           text: async (createNode, node, context) => {
@@ -52,10 +57,10 @@ describe('contentful-to-structured-text', () => {
     });
 
     it('can return an array of promises', async () => {
-      const html = `
+      const richText = `
         <p>twice</p>
       `;
-      const result = await richTextToStructuredText(html, {
+      const result = await richTextToStructuredText(richText, {
         handlers: {
           p: (createNode, node, context) => {
             return [
@@ -72,12 +77,12 @@ describe('contentful-to-structured-text', () => {
 
     describe('custom (user provided)', () => {
       it('can register custom handlers', async () => {
-        const html = `
+        const richText = `
           <unknown>span</unknown>
         <p>already wrapped</p>
         needs wrapping
       `;
-        const result = await richTextToStructuredText(html, {
+        const result = await richTextToStructuredText(richText, {
           handlers: {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             unknown: (createNode, node, context) => {
@@ -103,10 +108,10 @@ describe('contentful-to-structured-text', () => {
       });
 
       it('waits for async handlers to resolve', async () => {
-        const html = `
+        const richText = `
           <custom>span</custom>
       `;
-        const result = await richTextToStructuredText(html, {
+        const result = await richTextToStructuredText(richText, {
           handlers: {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             custom: async (createNode, node, context) => {
@@ -122,11 +127,11 @@ describe('contentful-to-structured-text', () => {
       });
 
       it('can override default handlers', async () => {
-        const html = `
+        const richText = `
           <blockquote>override</blockquote>
           <p>regular paragraph</p>
       `;
-        const result = await richTextToStructuredText(html, {
+        const result = await richTextToStructuredText(richText, {
           handlers: {
             blockquote: async (createNode, node, context) => {
               // turn a blockquote into a paragraph
@@ -145,7 +150,7 @@ describe('contentful-to-structured-text', () => {
 
     describe('root', () => {
       it('generates valid children', async () => {
-        const html = `
+        const richText = `
           <h1>heading</h1>
           <p>paragraph</p>
           implicit paragraph
@@ -158,7 +163,7 @@ describe('contentful-to-structured-text', () => {
           </section>
           <a href="#">hyperlink</a>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
 
         expect(
@@ -190,13 +195,13 @@ describe('contentful-to-structured-text', () => {
 
     describe('paragraph', () => {
       it('works', async () => {
-        const html = `
+        const richText = `
           <p>simple paragraph</p>
           <article>
             <p>nested simple paragraph</p>
           </article>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(result.document.children.map((child) => child.type))
           .toMatchInlineSnapshot(`
@@ -208,14 +213,14 @@ describe('contentful-to-structured-text', () => {
       });
 
       it('generates valid children', async () => {
-        const html = `
+        const richText = `
           <p>
             <span>[simple text]</span>
             <span>[span becomes simple text]</span>
             <span>[span becomes simple text]</span>
           </p>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(result.document.children).toMatchInlineSnapshot(`
           Array [
@@ -247,20 +252,20 @@ describe('contentful-to-structured-text', () => {
 
     describe('heading', () => {
       it('wraps children when necessary', async () => {
-        const html = `
+        const richText = `
           <h1>needs wrapping</h1>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(result.document.children[0].type).toBe('heading');
         expect(result.document.children[0].children[0].type).toBe('span');
       });
 
       it('allows link as children', async () => {
-        const html = `
+        const richText = `
           <h1>span <a href="#">link</a></h1>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(result.document.children[0].children).toMatchInlineSnapshot(`
           Array [
@@ -283,7 +288,7 @@ describe('contentful-to-structured-text', () => {
       });
 
       it('is converted to text when inside of another dast node (except root)', async () => {
-        const html = `
+        const richText = `
           <section>
             <ul>
               <h1>inside ul</h1>
@@ -295,16 +300,16 @@ describe('contentful-to-structured-text', () => {
             </code>
           </pre>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(findAll(result.document, 'heading')).toHaveLength(0);
       });
 
       it('when not allowed produces paragraphs', async () => {
-        const html = `
+        const richText = `
           <h1>dato</h1>
         `;
-        const result = await richTextToStructuredText(html, {
+        const result = await richTextToStructuredText(richText, {
           allowedBlocks: [],
         });
         expect(validate(result).valid).toBeTruthy();
@@ -316,25 +321,25 @@ describe('contentful-to-structured-text', () => {
 
     describe('code', () => {
       it('creates valid code node', async () => {
-        const html = `
-          <pre><code class="language-html"><span class="hljs-tag">&lt;<span class="hljs-name">import</span> <span class="hljs-attr">src</span>=<span class="hljs-string">"file.html"</span> /&gt;</span></code></pre>
+        const richText = `
+          <pre><code class="language-richText"><span class="hljs-tag">&lt;<span class="hljs-name">import</span> <span class="hljs-attr">src</span>=<span class="hljs-string">"file.richText"</span> /&gt;</span></code></pre>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(result.document.children[0]).toMatchInlineSnapshot(`
           Object {
-            "code": "<import src=\\"file.html\\" />",
-            "language": "html",
+            "code": "<import src=\\"file.richText\\" />",
+            "language": "richText",
             "type": "code",
           }
         `);
       });
 
       it('when not allowed produces paragraphs', async () => {
-        const html = `
+        const richText = `
           <code>let dato</code>
         `;
-        const result = await richTextToStructuredText(html, {
+        const result = await richTextToStructuredText(richText, {
           allowedBlocks: [],
         });
         expect(validate(result).valid).toBeTruthy();
@@ -346,11 +351,11 @@ describe('contentful-to-structured-text', () => {
 
     describe('blockquote', () => {
       it('creates valid blockquote node', async () => {
-        const html = `
+        const richText = `
           <blockquote>1</blockquote>
           <blockquote><span>2</span></blockquote>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(result.document.children.map((child) => child.type))
           .toMatchInlineSnapshot(`
@@ -378,10 +383,10 @@ describe('contentful-to-structured-text', () => {
       });
 
       it('when not allowed produces paragraphs', async () => {
-        const html = `
+        const richText = `
           <blockquote>dato</blockquote>
         `;
-        const result = await richTextToStructuredText(html, {
+        const result = await richTextToStructuredText(richText, {
           allowedBlocks: [],
         });
         expect(validate(result).valid).toBeTruthy();
@@ -393,78 +398,78 @@ describe('contentful-to-structured-text', () => {
 
     describe('list', () => {
       it('creates valid list', async () => {
-        const html = `
+        const richText = `
           <ul><li>test</li></ul>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(result.document.children[0].style).toBe('bulleted');
       });
 
       it('creates a numbered list from OL elements', async () => {
-        const html = `
+        const richText = `
           <ol><li>test</li></ol>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(result.document.children[0].style).toBe('numbered');
       });
 
       it('supports nested lists', async () => {
-        const html = `
+        const richText = `
           <ul>
             <li><ul><li>1</li></ul></li>
           </ul>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(find(find(result.document, 'list'), 'list')).toBeTruthy();
       });
 
       it('converts nested blockquote to text', async () => {
-        const html = `
+        const richText = `
           <ul>
             <li><blockquote>1</blockquote></li>
           </ul>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(findAll(result.document, 'blockquote')).toHaveLength(0);
         expect(find(result.document, 'span').value).toBe('1');
       });
 
       it('converts nested heading to text', async () => {
-        const html = `
+        const richText = `
           <ul>
             <li><h1>1</h1></li>
           </ul>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(findAll(result.document, 'h1')).toHaveLength(0);
         expect(find(result.document, 'span').value).toBe('1');
       });
 
       it('converts nested code to text', async () => {
-        const html = `
+        const richText = `
           <ul>
             <li><code>1</code></li>
           </ul>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(findAll(result.document, 'code')).toHaveLength(0);
         expect(find(result.document, 'span').value).toBe('1');
       });
 
       it('supports nested and/or unwrapped link', async () => {
-        const html = `
+        const richText = `
           <ul>
             <li><a href="#">1</a>2</li>
             <a href="#">3</a>
           </ul>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(findAll(result.document, 'link')).toHaveLength(2);
         const items = findAll(result.document, 'listItem').map((listItem) =>
@@ -484,12 +489,12 @@ describe('contentful-to-structured-text', () => {
       });
 
       it('when not allowed produces paragraphs', async () => {
-        const html = `
+        const richText = `
           <ul>
             <li>dato</li>
           </ul>
         `;
-        const result = await richTextToStructuredText(html, {
+        const result = await richTextToStructuredText(richText, {
           allowedBlocks: [],
         });
         expect(validate(result).valid).toBeTruthy();
@@ -501,13 +506,13 @@ describe('contentful-to-structured-text', () => {
 
     describe('thematicBreak', () => {
       it('convert hr', async () => {
-        const html = `
+        const richText = `
           <div>
             <hr>
             <blockquote>1<hr></blockquote>
           </div>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         const thematicBreaks = findAll(result.document, 'thematicBreak');
         expect(thematicBreaks).toHaveLength(1);
@@ -517,10 +522,10 @@ describe('contentful-to-structured-text', () => {
     describe('link', () => {
       // non credo che questo sia possibile con contentful
       it('is wrapped when top level', async () => {
-        const html = `
+        const richText = `
           <a href="#">1</a>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(result.document.children[0].type).toBe('paragraph');
         expect(find(find(result.document, 'paragraph'), 'link')).toBeTruthy();
@@ -528,10 +533,10 @@ describe('contentful-to-structured-text', () => {
 
       describe('when wrapping a heading', () => {
         it('lifts up heading to contain the link', async () => {
-          const html = `
+          const richText = `
             <a href="#"><h1>1</h1>2</a>
           `;
-          const result = await richTextToStructuredText(html);
+          const result = await richTextToStructuredText(richText);
           expect(validate(result).valid).toBeTruthy();
           expect(result.document.children[0].type).toBe('heading');
           expect(find(find(result.document, 'heading'), 'link')).toBeTruthy();
@@ -539,20 +544,20 @@ describe('contentful-to-structured-text', () => {
         });
 
         it('ignores heading when it is not allowed in the context (eg. list)', async () => {
-          const html = `
+          const richText = `
             <ul><a href="#"><h1>1</h1>2</a></ul>
           `;
-          const result = await richTextToStructuredText(html);
+          const result = await richTextToStructuredText(richText);
           expect(validate(result).valid).toBeTruthy();
           expect(findAll(result.document, 'heading')).toHaveLength(0);
         });
       });
 
       it('when not allowed produces paragraphs', async () => {
-        const html = `
+        const richText = `
           <a href="#"><h1>dato</h1>2</a>
         `;
-        const result = await richTextToStructuredText(html, {
+        const result = await richTextToStructuredText(richText, {
           allowedBlocks: [],
         });
         expect(validate(result).valid).toBeTruthy();
@@ -574,10 +579,10 @@ describe('contentful-to-structured-text', () => {
       describe('converts tags to marks', () => {
         it.each(Object.keys(marksTags))(`%p`, async (tagName) => {
           const markName = marksTags[tagName];
-          const html = `
+          const richText = `
           <p><${tagName}>${markName}</${tagName}></p>
         `;
-          const result = await richTextToStructuredText(html);
+          const result = await richTextToStructuredText(richText);
           expect(validate(result).valid).toBeTruthy();
           const span = find(result.document, 'span');
           expect(span.marks).toBeTruthy();
@@ -588,10 +593,10 @@ describe('contentful-to-structured-text', () => {
       describe('ignore mark tags when not in allowedMarks', () => {
         it.each(Object.keys(marksTags))(`%p`, async (tagName) => {
           const markName = marksTags[tagName];
-          const html = `
+          const richText = `
           <p><${tagName}>${markName}</${tagName}></p>
         `;
-          const result = await richTextToStructuredText(html, {
+          const result = await richTextToStructuredText(richText, {
             allowedMarks: [],
           });
           expect(validate(result).valid).toBeTruthy();
@@ -601,10 +606,10 @@ describe('contentful-to-structured-text', () => {
       });
 
       it('collects marks when nesting nodes', async () => {
-        const html = `
+        const richText = `
           <p><em>em<strong>strong-em<u>u-strong-em</u>strong-em</strong>em</em></p>
         `;
-        const result = await richTextToStructuredText(html);
+        const result = await richTextToStructuredText(richText);
         expect(validate(result).valid).toBeTruthy();
         expect(
           findAll(result.document, 'span')
@@ -626,13 +631,13 @@ describe('contentful-to-structured-text', () => {
 
       describe('code', () => {
         it('turns inline code tags to span with code mark', async () => {
-          const html = `
+          const richText = `
             <p>To make it even easier to offer responsive, progressive images on your projects, we released a package called 
             <a href="https://github.com/datocms/react-datocms">
             <code>react-datocms</code></a> that exposes an <code>&lt;Image /&gt;</code> 
             component and pairs perfectly with the <code>responsiveImage</code> query.
             </p>`;
-          const result = await richTextToStructuredText(html);
+          const result = await richTextToStructuredText(richText);
           expect(validate(result).valid).toBeTruthy();
           expect(findAll(result.document, 'code')).toHaveLength(0);
           const spans = findAll(result.document, 'span').filter(

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -264,7 +264,7 @@ describe('contentful-to-structured-text', () => {
             "paragraph",
             "blockquote",
             "list",
-            "paragraph",
+            "code",
             "paragraph",
           ]
         `);
@@ -1288,6 +1288,11 @@ describe('contentful-to-structured-text', () => {
                   nodeType: 'text',
                   value: 'foo',
                   marks: [{ type: markName }],
+                  data: {},
+                },
+                {
+                  nodeType: 'text',
+                  value: '.',
                   data: {},
                 },
               ],

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -519,35 +519,95 @@ describe('contentful-to-structured-text', () => {
     });
   });
 
-  //   describe('code', () => {
-  //     it('creates valid code node', async () => {
-  //       const richText = `
-  //         <pre><code class="language-richText"><span class="hljs-tag">&lt;<span class="hljs-name">import</span> <span class="hljs-attr">src</span>=<span class="hljs-string">"file.richText"</span> /&gt;</span></code></pre>
-  //       `;
-  //       const result = await richTextToStructuredText(richText);
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(result.document.children[0]).toMatchInlineSnapshot(`
-  //         Object {
-  //           "code": "<import src=\\"file.richText\\" />",
-  //           "language": "richText",
-  //           "type": "code",
-  //         }
-  //       `);
-  //     });
+  describe('code', () => {
+    const richText = {
+      nodeType: 'document',
+      data: {},
+      content: [
+        {
+          nodeType: 'text',
+          value: '<import src="file.richText" />',
+          marks: [{ type: 'code' }],
+          data: {},
+        },
+      ],
+    };
 
-  //     it('when not allowed produces paragraphs', async () => {
-  //       const richText = `
-  //         <code>let dato</code>
-  //       `;
-  //       const result = await richTextToStructuredText(richText, {
-  //         allowedBlocks: [],
-  //       });
-  //       expect(validate(result).valid).toBeTruthy();
-  //       expect(findAll(result.document, 'code')).toHaveLength(0);
-  //       expect(findAll(result.document, 'paragraph')).toHaveLength(1);
-  //       expect(find(result.document, 'span').value).toBe('let dato');
-  //     });
-  //   });
+    it('creates valid code node', async () => {
+      const result = await richTextToStructuredText(richText);
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0]).toMatchInlineSnapshot(`
+          Object {
+            "code": "<import src=\\"file.richText\\" />",
+            "type": "code",
+          }
+        `);
+    });
+
+    it('when not allowed, produces paragraphs', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'text',
+            value: '<import src="file.richText" />',
+            marks: [{ type: 'code' }],
+            data: {},
+          },
+        ],
+      };
+
+      const result = await richTextToStructuredText(richText, {
+        allowedBlocks: [],
+      });
+
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0].type).toBe('paragraph');
+      expect(result.document.children[0].children).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "marks": Array [
+                "code",
+              ],
+              "type": "span",
+              "value": "<import src=\\"file.richText\\" />",
+            },
+          ]
+        `);
+    });
+
+    it('when code not allowed in blocks and marks, produces paragraphs', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'text',
+            value: '<import src="file.richText" />',
+            marks: [{ type: 'code' }],
+            data: {},
+          },
+        ],
+      };
+
+      const result = await richTextToStructuredText(richText, {
+        allowedBlocks: [],
+        allowedMarks: ['strong'],
+      });
+
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children[0].type).toBe('paragraph');
+      expect(result.document.children[0].children).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "type": "span",
+              "value": "<import src=\\"file.richText\\" />",
+            },
+          ]
+        `);
+    });
+  });
 
   //   describe('blockquote', () => {
   //     it('creates valid blockquote node', async () => {

--- a/packages/contentful-to-structured-text/__tests__/all.test.ts
+++ b/packages/contentful-to-structured-text/__tests__/all.test.ts
@@ -3,6 +3,7 @@
 
 import { richTextToStructuredText } from '../src';
 import { allowedChildren, Span, validate } from 'datocms-structured-text-utils';
+import { inspect } from 'util';
 
 describe('contentful-to-structured-text', () => {
   it('works with empty document', async () => {
@@ -17,640 +18,662 @@ describe('contentful-to-structured-text', () => {
     expect(result).toMatchInlineSnapshot(`null`);
   });
 
-  it('rejects invalid rich text documents', async () => {
-    const richText = '';
-    const result = await richTextToStructuredText(richText);
-    expect(validate(result).valid).toBeTruthy();
-    expect(result).toMatchInlineSnapshot(`null`);
-  });
+  // it('rejects invalid rich text documents', async () => {
+  //   const richText = {
+  //     nodeType: 'foobar',
+  //     data: {},
+  //     content: [],
+  //   };
 
-  describe('handlers', () => {
-    it('can return an array of nodes', async () => {
-      const richText = `
-        <p>twice</p>
-      `;
+  //   const result = await richTextToStructuredText(richText);
+  //   expect(validate(result).valid).toBeFalsy();
+  //   expect(result).toMatchInlineSnapshot(`null`);
+  // });
 
-      const result = await richTextToStructuredText(richText, {
-        handlers: {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          text: async (createNode, node, context) => {
-            return await Promise.all([
-              createNode('span', {
-                value: node.value,
-              }),
-              createNode('span', {
-                value: node.value,
-              }),
-            ]);
+  // describe('handlers', () => {
+  //   it('can return an array of nodes', async () => {
+  //     const richText = {
+  //       nodeType: 'paragraph',
+  //       content: [{ nodeType: 'text', value: 'foo', marks: [], data: {} }],
+  //       data: {},
+  //     };
+
+  //     const result = await richTextToStructuredText(richText, {
+  //       handlers: {
+  //         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  //         text: async (createNode, node, context) => {
+  //           return await Promise.all([
+  //             createNode('span', {
+  //               value: node.value,
+  //             }),
+  //             createNode('span', {
+  //               value: node.value,
+  //             }),
+  //           ]);
+  //         },
+  //         paragraph: async (createNode, node, context) => {
+  //           return await Promise.all([
+  //             context.defaultHandlers.p(createNode, node, context),
+  //             context.defaultHandlers.p(createNode, node, context),
+  //           ]);
+  //         },
+  //       },
+  //     });
+  //     expect(validate(result).valid).toBeTruthy();
+  //     expect(findAll(result.document, 'paragraph')).toHaveLength(2);
+  //     expect(findAll(result.document, 'span')).toHaveLength(4);
+  //   });
+
+  //   //   it('can return an array of promises', async () => {
+  //   //     const richText = `
+  //   //       <p>twice</p>
+  //   //     `;
+  //   //     const result = await richTextToStructuredText(richText, {
+  //   //       handlers: {
+  //   //         p: (createNode, node, context) => {
+  //   //           return [
+  //   //             context.defaultHandlers.p(createNode, node, context),
+  //   //             context.defaultHandlers.p(createNode, node, context),
+  //   //           ];
+  //   //         },
+  //   //       },
+  //   //     });
+  //   //     expect(validate(result).valid).toBeTruthy();
+  //   //     expect(findAll(result.document, 'paragraph')).toHaveLength(2);
+  //   //     expect(findAll(result.document, 'span')).toHaveLength(2);
+  //   //   });
+
+  //   //   describe('custom (user provided)', () => {
+  //   //     it('can register custom handlers', async () => {
+  //   //       const richText = `
+  //   //         <unknown>span</unknown>
+  //   //       <p>already wrapped</p>
+  //   //       needs wrapping
+  //   //     `;
+  //   //       const result = await richTextToStructuredText(richText, {
+  //   //         handlers: {
+  //   //           // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  //   //           unknown: (createNode, node, context) => {
+  //   //             return createNode('span', {
+  //   //               value: 'custom',
+  //   //             });
+  //   //           },
+  //   //         },
+  //   //       });
+  //   //       expect(validate(result).valid).toBeTruthy();
+  //   //       const spans = findAll(result.document, 'span');
+  //   //       expect(spans).toHaveLength(3);
+  //   //       expect(spans[0].value).toBe('custom');
+  //   //       const paragraphs = findAll(result.document, 'paragraph');
+  //   //       expect(paragraphs.map((p) => p.children[0].value))
+  //   //         .toMatchInlineSnapshot(`
+  //   //         Array [
+  //   //           "custom",
+  //   //           "already wrapped",
+  //   //           "needs wrapping",
+  //   //         ]
+  //   //       `);
+  //   //     });
+
+  //   //     it('waits for async handlers to resolve', async () => {
+  //   //       const richText = `
+  //   //         <custom>span</custom>
+  //   //     `;
+  //   //       const result = await richTextToStructuredText(richText, {
+  //   //         handlers: {
+  //   //           // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  //   //           custom: async (createNode, node, context) => {
+  //   //             await new Promise((resolve) => setTimeout(resolve, 200));
+  //   //             return createNode('span', {
+  //   //               value: 'custom',
+  //   //             });
+  //   //           },
+  //   //         },
+  //   //       });
+  //   //       expect(validate(result).valid).toBeTruthy();
+  //   //       expect(find(result.document, 'span').value).toBe('custom');
+  //   //     });
+
+  //   //     it('can override default handlers', async () => {
+  //   //       const richText = `
+  //   //         <blockquote>override</blockquote>
+  //   //         <p>regular paragraph</p>
+  //   //     `;
+  //   //       const result = await richTextToStructuredText(richText, {
+  //   //         handlers: {
+  //   //           blockquote: async (createNode, node, context) => {
+  //   //             // turn a blockquote into a paragraph
+  //   //             return context.handlers.p(createNode, node, context);
+  //   //           },
+  //   //         },
+  //   //       });
+  //   //       expect(validate(result).valid).toBeTruthy();
+  //   //       expect(find(result.document, 'blockquote')).toBeFalsy();
+  //   //       const paragraphs = findAll(result.document, 'paragraph');
+  //   //       expect(paragraphs).toHaveLength(2);
+  //   //       expect(find(paragraphs[0], 'span').value).toBe('override');
+  //   //       expect(find(paragraphs[1], 'span').value).toBe('regular paragraph');
+  //   //     });
+  // });
+
+  //   describe('root', () => {
+  //     it('generates valid children', async () => {
+  //       const richText = `
+  //         <h1>heading</h1>
+  //         <p>paragraph</p>
+  //         implicit paragraph
+  //         <blockquote>blockquote</blockquote>
+  //         <pre>code</pre>
+  //         <ul><li>list</li></ul>
+  //         <strong>inline wrapped</strong>
+  //         <section>
+  //           <div><div>inline nested</div></div>
+  //         </section>
+  //         <a href="#">hyperlink</a>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+
+  //       expect(
+  //         result.document.children.every((child) =>
+  //           allowedChildren['root'].includes(child.type),
+  //         ),
+  //       ).toBeTruthy();
+
+  //       // The following is grouped in a single paragraph. I think it is fine.
+  //       // <strong>inline wrapped</strong>
+  //       // <section>
+  //       //   <div><div>inline nested</div></div>
+  //       // </section>
+  //       // <a href="#">hyperlink</a>
+  //       expect(result.document.children.map((child) => child.type))
+  //         .toMatchInlineSnapshot(`
+  //         Array [
+  //           "heading",
+  //           "paragraph",
+  //           "paragraph",
+  //           "blockquote",
+  //           "code",
+  //           "list",
+  //           "paragraph",
+  //         ]
+  //       `);
+  //     });
+  //   });
+
+  describe('paragraph', () => {
+    it('works', async () => {
+      const richText = {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'paragraph',
+            content: [{ nodeType: 'text', value: 'foo', marks: [], data: {} }],
+            data: {},
           },
-          p: async (createNode, node, context) => {
-            return await Promise.all([
-              context.defaultHandlers.p(createNode, node, context),
-              context.defaultHandlers.p(createNode, node, context),
-            ]);
+          {
+            nodeType: 'paragraph',
+            content: [{ nodeType: 'text', value: 'bar', marks: [], data: {} }],
+            data: {},
           },
-        },
-      });
-      expect(validate(result).valid).toBeTruthy();
-      expect(findAll(result.document, 'paragraph')).toHaveLength(2);
-      expect(findAll(result.document, 'span')).toHaveLength(4);
-    });
-
-    it('can return an array of promises', async () => {
-      const richText = `
-        <p>twice</p>
-      `;
-      const result = await richTextToStructuredText(richText, {
-        handlers: {
-          p: (createNode, node, context) => {
-            return [
-              context.defaultHandlers.p(createNode, node, context),
-              context.defaultHandlers.p(createNode, node, context),
-            ];
-          },
-        },
-      });
-      expect(validate(result).valid).toBeTruthy();
-      expect(findAll(result.document, 'paragraph')).toHaveLength(2);
-      expect(findAll(result.document, 'span')).toHaveLength(2);
-    });
-
-    describe('custom (user provided)', () => {
-      it('can register custom handlers', async () => {
-        const richText = `
-          <unknown>span</unknown>
-        <p>already wrapped</p>
-        needs wrapping
-      `;
-        const result = await richTextToStructuredText(richText, {
-          handlers: {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            unknown: (createNode, node, context) => {
-              return createNode('span', {
-                value: 'custom',
-              });
-            },
-          },
-        });
-        expect(validate(result).valid).toBeTruthy();
-        const spans = findAll(result.document, 'span');
-        expect(spans).toHaveLength(3);
-        expect(spans[0].value).toBe('custom');
-        const paragraphs = findAll(result.document, 'paragraph');
-        expect(paragraphs.map((p) => p.children[0].value))
-          .toMatchInlineSnapshot(`
-          Array [
-            "custom",
-            "already wrapped",
-            "needs wrapping",
-          ]
-        `);
-      });
-
-      it('waits for async handlers to resolve', async () => {
-        const richText = `
-          <custom>span</custom>
-      `;
-        const result = await richTextToStructuredText(richText, {
-          handlers: {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            custom: async (createNode, node, context) => {
-              await new Promise((resolve) => setTimeout(resolve, 200));
-              return createNode('span', {
-                value: 'custom',
-              });
-            },
-          },
-        });
-        expect(validate(result).valid).toBeTruthy();
-        expect(find(result.document, 'span').value).toBe('custom');
-      });
-
-      it('can override default handlers', async () => {
-        const richText = `
-          <blockquote>override</blockquote>
-          <p>regular paragraph</p>
-      `;
-        const result = await richTextToStructuredText(richText, {
-          handlers: {
-            blockquote: async (createNode, node, context) => {
-              // turn a blockquote into a paragraph
-              return context.handlers.p(createNode, node, context);
-            },
-          },
-        });
-        expect(validate(result).valid).toBeTruthy();
-        expect(find(result.document, 'blockquote')).toBeFalsy();
-        const paragraphs = findAll(result.document, 'paragraph');
-        expect(paragraphs).toHaveLength(2);
-        expect(find(paragraphs[0], 'span').value).toBe('override');
-        expect(find(paragraphs[1], 'span').value).toBe('regular paragraph');
-      });
-    });
-
-    describe('root', () => {
-      it('generates valid children', async () => {
-        const richText = `
-          <h1>heading</h1>
-          <p>paragraph</p>
-          implicit paragraph
-          <blockquote>blockquote</blockquote>
-          <pre>code</pre>
-          <ul><li>list</li></ul>
-          <strong>inline wrapped</strong>
-          <section>
-            <div><div>inline nested</div></div>
-          </section>
-          <a href="#">hyperlink</a>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-
-        expect(
-          result.document.children.every((child) =>
-            allowedChildren['root'].includes(child.type),
-          ),
-        ).toBeTruthy();
-
-        // The following is grouped in a single paragraph. I think it is fine.
-        // <strong>inline wrapped</strong>
-        // <section>
-        //   <div><div>inline nested</div></div>
-        // </section>
-        // <a href="#">hyperlink</a>
-        expect(result.document.children.map((child) => child.type))
-          .toMatchInlineSnapshot(`
-          Array [
-            "heading",
-            "paragraph",
-            "paragraph",
-            "blockquote",
-            "code",
-            "list",
-            "paragraph",
-          ]
-        `);
-      });
-    });
-
-    describe('paragraph', () => {
-      it('works', async () => {
-        const richText = `
-          <p>simple paragraph</p>
-          <article>
-            <p>nested simple paragraph</p>
-          </article>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(result.document.children.map((child) => child.type))
-          .toMatchInlineSnapshot(`
-          Array [
-            "paragraph",
-            "paragraph",
-          ]
-        `);
-      });
-
-      it('generates valid children', async () => {
-        const richText = `
-          <p>
-            <span>[simple text]</span>
-            <span>[span becomes simple text]</span>
-            <span>[span becomes simple text]</span>
-          </p>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(result.document.children).toMatchInlineSnapshot(`
-          Array [
-            Object {
-              "children": Array [
-                Object {
-                  "type": "span",
-                  "value": "[simple text] ",
-                },
-                Object {
-                  "type": "span",
-                  "value": "[span becomes simple text]",
-                },
-                Object {
-                  "type": "span",
-                  "value": " ",
-                },
-                Object {
-                  "type": "span",
-                  "value": "[span becomes simple text]",
-                },
-              ],
-              "type": "paragraph",
-            },
-          ]
-        `);
-      });
-    });
-
-    describe('heading', () => {
-      it('wraps children when necessary', async () => {
-        const richText = `
-          <h1>needs wrapping</h1>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(result.document.children[0].type).toBe('heading');
-        expect(result.document.children[0].children[0].type).toBe('span');
-      });
-
-      it('allows link as children', async () => {
-        const richText = `
-          <h1>span <a href="#">link</a></h1>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(result.document.children[0].children).toMatchInlineSnapshot(`
-          Array [
-            Object {
-              "type": "span",
-              "value": "span ",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "type": "span",
-                  "value": "link",
-                },
-              ],
-              "type": "link",
-              "url": "#",
-            },
-          ]
-        `);
-      });
-
-      it('is converted to text when inside of another dast node (except root)', async () => {
-        const richText = `
-          <section>
-            <ul>
-              <h1>inside ul</h1>
-            </ul>
-          </section>
-          <pre>
-            <code>
-              <h1>inside code</h1>
-            </code>
-          </pre>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(findAll(result.document, 'heading')).toHaveLength(0);
-      });
-
-      it('when not allowed produces paragraphs', async () => {
-        const richText = `
-          <h1>dato</h1>
-        `;
-        const result = await richTextToStructuredText(richText, {
-          allowedBlocks: [],
-        });
-        expect(validate(result).valid).toBeTruthy();
-        expect(findAll(result.document, 'heading')).toHaveLength(0);
-        expect(findAll(result.document, 'paragraph')).toHaveLength(1);
-        expect(find(result.document, 'span').value).toBe('dato');
-      });
-    });
-
-    describe('code', () => {
-      it('creates valid code node', async () => {
-        const richText = `
-          <pre><code class="language-richText"><span class="hljs-tag">&lt;<span class="hljs-name">import</span> <span class="hljs-attr">src</span>=<span class="hljs-string">"file.richText"</span> /&gt;</span></code></pre>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(result.document.children[0]).toMatchInlineSnapshot(`
-          Object {
-            "code": "<import src=\\"file.richText\\" />",
-            "language": "richText",
-            "type": "code",
-          }
-        `);
-      });
-
-      it('when not allowed produces paragraphs', async () => {
-        const richText = `
-          <code>let dato</code>
-        `;
-        const result = await richTextToStructuredText(richText, {
-          allowedBlocks: [],
-        });
-        expect(validate(result).valid).toBeTruthy();
-        expect(findAll(result.document, 'code')).toHaveLength(0);
-        expect(findAll(result.document, 'paragraph')).toHaveLength(1);
-        expect(find(result.document, 'span').value).toBe('let dato');
-      });
-    });
-
-    describe('blockquote', () => {
-      it('creates valid blockquote node', async () => {
-        const richText = `
-          <blockquote>1</blockquote>
-          <blockquote><span>2</span></blockquote>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(result.document.children.map((child) => child.type))
-          .toMatchInlineSnapshot(`
-          Array [
-            "blockquote",
-            "blockquote",
-          ]
-        `);
-        expect(result.document.children[0]).toMatchInlineSnapshot(`
-          Object {
-            "children": Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "type": "span",
-                    "value": "1",
-                  },
-                ],
-                "type": "paragraph",
-              },
-            ],
-            "type": "blockquote",
-          }
-        `);
-      });
-
-      it('when not allowed produces paragraphs', async () => {
-        const richText = `
-          <blockquote>dato</blockquote>
-        `;
-        const result = await richTextToStructuredText(richText, {
-          allowedBlocks: [],
-        });
-        expect(validate(result).valid).toBeTruthy();
-        expect(findAll(result.document, 'blockquote')).toHaveLength(0);
-        expect(findAll(result.document, 'paragraph')).toHaveLength(1);
-        expect(find(result.document, 'span').value).toBe('dato');
-      });
-    });
-
-    describe('list', () => {
-      it('creates valid list', async () => {
-        const richText = `
-          <ul><li>test</li></ul>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(result.document.children[0].style).toBe('bulleted');
-      });
-
-      it('creates a numbered list from OL elements', async () => {
-        const richText = `
-          <ol><li>test</li></ol>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(result.document.children[0].style).toBe('numbered');
-      });
-
-      it('supports nested lists', async () => {
-        const richText = `
-          <ul>
-            <li><ul><li>1</li></ul></li>
-          </ul>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(find(find(result.document, 'list'), 'list')).toBeTruthy();
-      });
-
-      it('converts nested blockquote to text', async () => {
-        const richText = `
-          <ul>
-            <li><blockquote>1</blockquote></li>
-          </ul>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(findAll(result.document, 'blockquote')).toHaveLength(0);
-        expect(find(result.document, 'span').value).toBe('1');
-      });
-
-      it('converts nested heading to text', async () => {
-        const richText = `
-          <ul>
-            <li><h1>1</h1></li>
-          </ul>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(findAll(result.document, 'h1')).toHaveLength(0);
-        expect(find(result.document, 'span').value).toBe('1');
-      });
-
-      it('converts nested code to text', async () => {
-        const richText = `
-          <ul>
-            <li><code>1</code></li>
-          </ul>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(findAll(result.document, 'code')).toHaveLength(0);
-        expect(find(result.document, 'span').value).toBe('1');
-      });
-
-      it('supports nested and/or unwrapped link', async () => {
-        const richText = `
-          <ul>
-            <li><a href="#">1</a>2</li>
-            <a href="#">3</a>
-          </ul>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(findAll(result.document, 'link')).toHaveLength(2);
-        const items = findAll(result.document, 'listItem').map((listItem) =>
-          find(listItem, 'paragraph').children.map((child) => child.type),
-        );
-        expect(items).toMatchInlineSnapshot(`
-          Array [
-            Array [
-              "link",
-              "span",
-            ],
-            Array [
-              "link",
-            ],
-          ]
-        `);
-      });
-
-      it('when not allowed produces paragraphs', async () => {
-        const richText = `
-          <ul>
-            <li>dato</li>
-          </ul>
-        `;
-        const result = await richTextToStructuredText(richText, {
-          allowedBlocks: [],
-        });
-        expect(validate(result).valid).toBeTruthy();
-        expect(findAll(result.document, 'list')).toHaveLength(0);
-        expect(findAll(result.document, 'paragraph')).toHaveLength(1);
-        expect(find(result.document, 'span').value).toBe('dato');
-      });
-    });
-
-    describe('thematicBreak', () => {
-      it('convert hr', async () => {
-        const richText = `
-          <div>
-            <hr>
-            <blockquote>1<hr></blockquote>
-          </div>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        const thematicBreaks = findAll(result.document, 'thematicBreak');
-        expect(thematicBreaks).toHaveLength(1);
-      });
-    });
-
-    describe('link', () => {
-      // non credo che questo sia possibile con contentful
-      it('is wrapped when top level', async () => {
-        const richText = `
-          <a href="#">1</a>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(result.document.children[0].type).toBe('paragraph');
-        expect(find(find(result.document, 'paragraph'), 'link')).toBeTruthy();
-      });
-
-      describe('when wrapping a heading', () => {
-        it('lifts up heading to contain the link', async () => {
-          const richText = `
-            <a href="#"><h1>1</h1>2</a>
-          `;
-          const result = await richTextToStructuredText(richText);
-          expect(validate(result).valid).toBeTruthy();
-          expect(result.document.children[0].type).toBe('heading');
-          expect(find(find(result.document, 'heading'), 'link')).toBeTruthy();
-          expect(find(find(result.document, 'paragraph'), 'link')).toBeTruthy();
-        });
-
-        it('ignores heading when it is not allowed in the context (eg. list)', async () => {
-          const richText = `
-            <ul><a href="#"><h1>1</h1>2</a></ul>
-          `;
-          const result = await richTextToStructuredText(richText);
-          expect(validate(result).valid).toBeTruthy();
-          expect(findAll(result.document, 'heading')).toHaveLength(0);
-        });
-      });
-
-      it('when not allowed produces paragraphs', async () => {
-        const richText = `
-          <a href="#"><h1>dato</h1>2</a>
-        `;
-        const result = await richTextToStructuredText(richText, {
-          allowedBlocks: [],
-        });
-        expect(validate(result).valid).toBeTruthy();
-        expect(findAll(result.document, 'link')).toHaveLength(0);
-        expect(findAll(result.document, 'heading')).toHaveLength(0);
-        expect(findAll(result.document, 'paragraph')).toHaveLength(1);
-        expect(find(result.document, 'span').value).toBe('dato');
-      });
-    });
-
-    describe('with Marks', () => {
-      const marksTags = {
-        bold: 'strong',
-        italic: 'emphasis',
-        underline: 'underline',
-        code: 'code',
+        ],
       };
 
-      describe('converts tags to marks', () => {
-        it.each(Object.keys(marksTags))(`%p`, async (tagName) => {
-          const markName = marksTags[tagName];
-          const richText = `
-          <p><${tagName}>${markName}</${tagName}></p>
-        `;
-          const result = await richTextToStructuredText(richText);
-          expect(validate(result).valid).toBeTruthy();
-          const span = find(result.document, 'span');
-          expect(span.marks).toBeTruthy();
-          expect(span.marks).toContain(markName);
-        });
-      });
+      const result = await richTextToStructuredText(richText);
+      console.log('[[[[[[[[[[[[[[[[[');
+      console.log(inspect(result, { depth: Infinity }));
+      console.log('[[[[[[[[[[[[[[[[[');
 
-      describe('ignore mark tags when not in allowedMarks', () => {
-        it.each(Object.keys(marksTags))(`%p`, async (tagName) => {
-          const markName = marksTags[tagName];
-          const richText = `
-          <p><${tagName}>${markName}</${tagName}></p>
-        `;
-          const result = await richTextToStructuredText(richText, {
-            allowedMarks: [],
-          });
-          expect(validate(result).valid).toBeTruthy();
-          const span = find(result.document, 'span');
-          expect(span.marks).toBeFalsy();
-        });
-      });
-
-      it('collects marks when nesting nodes', async () => {
-        const richText = `
-          <p><em>em<strong>strong-em<u>u-strong-em</u>strong-em</strong>em</em></p>
-        `;
-        const result = await richTextToStructuredText(richText);
-        expect(validate(result).valid).toBeTruthy();
-        expect(
-          findAll(result.document, 'span')
-            .map(
-              (span) =>
-                `{ value: '${span.value}', marks: ['${span.marks.join(
-                  "', '",
-                )}'] }`,
-            )
-            .join('\n'),
-        ).toMatchInlineSnapshot(`
-          "{ value: 'em', marks: ['emphasis'] }
-          { value: 'strong-em', marks: ['emphasis', 'strong'] }
-          { value: 'u-strong-em', marks: ['emphasis', 'strong', 'underline'] }
-          { value: 'strong-em', marks: ['emphasis', 'strong'] }
-          { value: 'em', marks: ['emphasis'] }"
+      expect(validate(result).valid).toBeTruthy();
+      expect(result.document.children.map((child) => child.type))
+        .toMatchInlineSnapshot(`
+          Array [
+            "paragraph",
+            "paragraph",
+          ]
         `);
-      });
-
-      describe('code', () => {
-        it('turns inline code tags to span with code mark', async () => {
-          const richText = `
-            <p>To make it even easier to offer responsive, progressive images on your projects, we released a package called 
-            <a href="https://github.com/datocms/react-datocms">
-            <code>react-datocms</code></a> that exposes an <code>&lt;Image /&gt;</code> 
-            component and pairs perfectly with the <code>responsiveImage</code> query.
-            </p>`;
-          const result = await richTextToStructuredText(richText);
-          expect(validate(result).valid).toBeTruthy();
-          expect(findAll(result.document, 'code')).toHaveLength(0);
-          const spans = findAll(result.document, 'span').filter(
-            (s) => Array.isArray(s.marks) && s.marks.includes('code'),
-          );
-          expect(spans).toHaveLength(3);
-          expect(spans.map((s) => s.value).join('\n')).toMatchInlineSnapshot(`
-            "react-datocms
-            <Image />
-            responsiveImage"
-          `);
-        });
-      });
     });
+
+    // it('generates valid children', async () => {
+    //   const richText = `
+    //       <p>
+    //         <span>[simple text]</span>
+    //         <span>[span becomes simple text]</span>
+    //         <span>[span becomes simple text]</span>
+    //       </p>
+    //     `;
+    //   const result = await richTextToStructuredText(richText);
+    //   expect(validate(result).valid).toBeTruthy();
+    //   expect(result.document.children).toMatchInlineSnapshot(`
+    //       Array [
+    //         Object {
+    //           "children": Array [
+    //             Object {
+    //               "type": "span",
+    //               "value": "[simple text] ",
+    //             },
+    //             Object {
+    //               "type": "span",
+    //               "value": "[span becomes simple text]",
+    //             },
+    //             Object {
+    //               "type": "span",
+    //               "value": " ",
+    //             },
+    //             Object {
+    //               "type": "span",
+    //               "value": "[span becomes simple text]",
+    //             },
+    //           ],
+    //           "type": "paragraph",
+    //         },
+    //       ]
+    //     `);
+    // });
   });
+
+  //   describe('heading', () => {
+  //     it('wraps children when necessary', async () => {
+  //       const richText = `
+  //         <h1>needs wrapping</h1>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(result.document.children[0].type).toBe('heading');
+  //       expect(result.document.children[0].children[0].type).toBe('span');
+  //     });
+
+  //     it('allows link as children', async () => {
+  //       const richText = `
+  //         <h1>span <a href="#">link</a></h1>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(result.document.children[0].children).toMatchInlineSnapshot(`
+  //         Array [
+  //           Object {
+  //             "type": "span",
+  //             "value": "span ",
+  //           },
+  //           Object {
+  //             "children": Array [
+  //               Object {
+  //                 "type": "span",
+  //                 "value": "link",
+  //               },
+  //             ],
+  //             "type": "link",
+  //             "url": "#",
+  //           },
+  //         ]
+  //       `);
+  //     });
+
+  //     it('is converted to text when inside of another dast node (except root)', async () => {
+  //       const richText = `
+  //         <section>
+  //           <ul>
+  //             <h1>inside ul</h1>
+  //           </ul>
+  //         </section>
+  //         <pre>
+  //           <code>
+  //             <h1>inside code</h1>
+  //           </code>
+  //         </pre>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(findAll(result.document, 'heading')).toHaveLength(0);
+  //     });
+
+  //     it('when not allowed produces paragraphs', async () => {
+  //       const richText = `
+  //         <h1>dato</h1>
+  //       `;
+  //       const result = await richTextToStructuredText(richText, {
+  //         allowedBlocks: [],
+  //       });
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(findAll(result.document, 'heading')).toHaveLength(0);
+  //       expect(findAll(result.document, 'paragraph')).toHaveLength(1);
+  //       expect(find(result.document, 'span').value).toBe('dato');
+  //     });
+  //   });
+
+  //   describe('code', () => {
+  //     it('creates valid code node', async () => {
+  //       const richText = `
+  //         <pre><code class="language-richText"><span class="hljs-tag">&lt;<span class="hljs-name">import</span> <span class="hljs-attr">src</span>=<span class="hljs-string">"file.richText"</span> /&gt;</span></code></pre>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(result.document.children[0]).toMatchInlineSnapshot(`
+  //         Object {
+  //           "code": "<import src=\\"file.richText\\" />",
+  //           "language": "richText",
+  //           "type": "code",
+  //         }
+  //       `);
+  //     });
+
+  //     it('when not allowed produces paragraphs', async () => {
+  //       const richText = `
+  //         <code>let dato</code>
+  //       `;
+  //       const result = await richTextToStructuredText(richText, {
+  //         allowedBlocks: [],
+  //       });
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(findAll(result.document, 'code')).toHaveLength(0);
+  //       expect(findAll(result.document, 'paragraph')).toHaveLength(1);
+  //       expect(find(result.document, 'span').value).toBe('let dato');
+  //     });
+  //   });
+
+  //   describe('blockquote', () => {
+  //     it('creates valid blockquote node', async () => {
+  //       const richText = `
+  //         <blockquote>1</blockquote>
+  //         <blockquote><span>2</span></blockquote>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(result.document.children.map((child) => child.type))
+  //         .toMatchInlineSnapshot(`
+  //         Array [
+  //           "blockquote",
+  //           "blockquote",
+  //         ]
+  //       `);
+  //       expect(result.document.children[0]).toMatchInlineSnapshot(`
+  //         Object {
+  //           "children": Array [
+  //             Object {
+  //               "children": Array [
+  //                 Object {
+  //                   "type": "span",
+  //                   "value": "1",
+  //                 },
+  //               ],
+  //               "type": "paragraph",
+  //             },
+  //           ],
+  //           "type": "blockquote",
+  //         }
+  //       `);
+  //     });
+
+  //     it('when not allowed produces paragraphs', async () => {
+  //       const richText = `
+  //         <blockquote>dato</blockquote>
+  //       `;
+  //       const result = await richTextToStructuredText(richText, {
+  //         allowedBlocks: [],
+  //       });
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(findAll(result.document, 'blockquote')).toHaveLength(0);
+  //       expect(findAll(result.document, 'paragraph')).toHaveLength(1);
+  //       expect(find(result.document, 'span').value).toBe('dato');
+  //     });
+  //   });
+
+  //   describe('list', () => {
+  //     it('creates valid list', async () => {
+  //       const richText = `
+  //         <ul><li>test</li></ul>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(result.document.children[0].style).toBe('bulleted');
+  //     });
+
+  //     it('creates a numbered list from OL elements', async () => {
+  //       const richText = `
+  //         <ol><li>test</li></ol>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(result.document.children[0].style).toBe('numbered');
+  //     });
+
+  //     it('supports nested lists', async () => {
+  //       const richText = `
+  //         <ul>
+  //           <li><ul><li>1</li></ul></li>
+  //         </ul>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(find(find(result.document, 'list'), 'list')).toBeTruthy();
+  //     });
+
+  //     it('converts nested blockquote to text', async () => {
+  //       const richText = `
+  //         <ul>
+  //           <li><blockquote>1</blockquote></li>
+  //         </ul>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(findAll(result.document, 'blockquote')).toHaveLength(0);
+  //       expect(find(result.document, 'span').value).toBe('1');
+  //     });
+
+  //     it('converts nested heading to text', async () => {
+  //       const richText = `
+  //         <ul>
+  //           <li><h1>1</h1></li>
+  //         </ul>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(findAll(result.document, 'h1')).toHaveLength(0);
+  //       expect(find(result.document, 'span').value).toBe('1');
+  //     });
+
+  //     it('converts nested code to text', async () => {
+  //       const richText = `
+  //         <ul>
+  //           <li><code>1</code></li>
+  //         </ul>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(findAll(result.document, 'code')).toHaveLength(0);
+  //       expect(find(result.document, 'span').value).toBe('1');
+  //     });
+
+  //     it('supports nested and/or unwrapped link', async () => {
+  //       const richText = `
+  //         <ul>
+  //           <li><a href="#">1</a>2</li>
+  //           <a href="#">3</a>
+  //         </ul>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(findAll(result.document, 'link')).toHaveLength(2);
+  //       const items = findAll(result.document, 'listItem').map((listItem) =>
+  //         find(listItem, 'paragraph').children.map((child) => child.type),
+  //       );
+  //       expect(items).toMatchInlineSnapshot(`
+  //         Array [
+  //           Array [
+  //             "link",
+  //             "span",
+  //           ],
+  //           Array [
+  //             "link",
+  //           ],
+  //         ]
+  //       `);
+  //     });
+
+  //     it('when not allowed produces paragraphs', async () => {
+  //       const richText = `
+  //         <ul>
+  //           <li>dato</li>
+  //         </ul>
+  //       `;
+  //       const result = await richTextToStructuredText(richText, {
+  //         allowedBlocks: [],
+  //       });
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(findAll(result.document, 'list')).toHaveLength(0);
+  //       expect(findAll(result.document, 'paragraph')).toHaveLength(1);
+  //       expect(find(result.document, 'span').value).toBe('dato');
+  //     });
+  //   });
+
+  //   describe('thematicBreak', () => {
+  //     it('convert hr', async () => {
+  //       const richText = `
+  //         <div>
+  //           <hr>
+  //           <blockquote>1<hr></blockquote>
+  //         </div>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       const thematicBreaks = findAll(result.document, 'thematicBreak');
+  //       expect(thematicBreaks).toHaveLength(1);
+  //     });
+  //   });
+
+  //   describe('link', () => {
+  //     // non credo che questo sia possibile con contentful
+  //     it('is wrapped when top level', async () => {
+  //       const richText = `
+  //         <a href="#">1</a>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(result.document.children[0].type).toBe('paragraph');
+  //       expect(find(find(result.document, 'paragraph'), 'link')).toBeTruthy();
+  //     });
+
+  //     describe('when wrapping a heading', () => {
+  //       it('lifts up heading to contain the link', async () => {
+  //         const richText = `
+  //           <a href="#"><h1>1</h1>2</a>
+  //         `;
+  //         const result = await richTextToStructuredText(richText);
+  //         expect(validate(result).valid).toBeTruthy();
+  //         expect(result.document.children[0].type).toBe('heading');
+  //         expect(find(find(result.document, 'heading'), 'link')).toBeTruthy();
+  //         expect(find(find(result.document, 'paragraph'), 'link')).toBeTruthy();
+  //       });
+
+  //       it('ignores heading when it is not allowed in the context (eg. list)', async () => {
+  //         const richText = `
+  //           <ul><a href="#"><h1>1</h1>2</a></ul>
+  //         `;
+  //         const result = await richTextToStructuredText(richText);
+  //         expect(validate(result).valid).toBeTruthy();
+  //         expect(findAll(result.document, 'heading')).toHaveLength(0);
+  //       });
+  //     });
+
+  //     it('when not allowed produces paragraphs', async () => {
+  //       const richText = `
+  //         <a href="#"><h1>dato</h1>2</a>
+  //       `;
+  //       const result = await richTextToStructuredText(richText, {
+  //         allowedBlocks: [],
+  //       });
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(findAll(result.document, 'link')).toHaveLength(0);
+  //       expect(findAll(result.document, 'heading')).toHaveLength(0);
+  //       expect(findAll(result.document, 'paragraph')).toHaveLength(1);
+  //       expect(find(result.document, 'span').value).toBe('dato');
+  //     });
+  //   });
+
+  //   describe('with Marks', () => {
+  //     const marksTags = {
+  //       bold: 'strong',
+  //       italic: 'emphasis',
+  //       underline: 'underline',
+  //       code: 'code',
+  //     };
+
+  //     describe('converts tags to marks', () => {
+  //       it.each(Object.keys(marksTags))(`%p`, async (tagName) => {
+  //         const markName = marksTags[tagName];
+  //         const richText = `
+  //         <p><${tagName}>${markName}</${tagName}></p>
+  //       `;
+  //         const result = await richTextToStructuredText(richText);
+  //         expect(validate(result).valid).toBeTruthy();
+  //         const span = find(result.document, 'span');
+  //         expect(span.marks).toBeTruthy();
+  //         expect(span.marks).toContain(markName);
+  //       });
+  //     });
+
+  //     describe('ignore mark tags when not in allowedMarks', () => {
+  //       it.each(Object.keys(marksTags))(`%p`, async (tagName) => {
+  //         const markName = marksTags[tagName];
+  //         const richText = `
+  //         <p><${tagName}>${markName}</${tagName}></p>
+  //       `;
+  //         const result = await richTextToStructuredText(richText, {
+  //           allowedMarks: [],
+  //         });
+  //         expect(validate(result).valid).toBeTruthy();
+  //         const span = find(result.document, 'span');
+  //         expect(span.marks).toBeFalsy();
+  //       });
+  //     });
+
+  //     it('collects marks when nesting nodes', async () => {
+  //       const richText = `
+  //         <p><em>em<strong>strong-em<u>u-strong-em</u>strong-em</strong>em</em></p>
+  //       `;
+  //       const result = await richTextToStructuredText(richText);
+  //       expect(validate(result).valid).toBeTruthy();
+  //       expect(
+  //         findAll(result.document, 'span')
+  //           .map(
+  //             (span) =>
+  //               `{ value: '${span.value}', marks: ['${span.marks.join(
+  //                 "', '",
+  //               )}'] }`,
+  //           )
+  //           .join('\n'),
+  //       ).toMatchInlineSnapshot(`
+  //         "{ value: 'em', marks: ['emphasis'] }
+  //         { value: 'strong-em', marks: ['emphasis', 'strong'] }
+  //         { value: 'u-strong-em', marks: ['emphasis', 'strong', 'underline'] }
+  //         { value: 'strong-em', marks: ['emphasis', 'strong'] }
+  //         { value: 'em', marks: ['emphasis'] }"
+  //       `);
+  //     });
+
+  //     describe('code', () => {
+  //       it('turns inline code tags to span with code mark', async () => {
+  //         const richText = `
+  //           <p>To make it even easier to offer responsive, progressive images on your projects, we released a package called
+  //           <a href="https://github.com/datocms/react-datocms">
+  //           <code>react-datocms</code></a> that exposes an <code>&lt;Image /&gt;</code>
+  //           component and pairs perfectly with the <code>responsiveImage</code> query.
+  //           </p>`;
+  //         const result = await richTextToStructuredText(richText);
+  //         expect(validate(result).valid).toBeTruthy();
+  //         expect(findAll(result.document, 'code')).toHaveLength(0);
+  //         const spans = findAll(result.document, 'span').filter(
+  //           (s) => Array.isArray(s.marks) && s.marks.includes('code'),
+  //         );
+  //         expect(spans).toHaveLength(3);
+  //         expect(spans.map((s) => s.value).join('\n')).toMatchInlineSnapshot(`
+  //           "react-datocms
+  //           <Image />
+  //           responsiveImage"
+  //         `);
+  //       });
+  //     });
+  //   });
+  // });
 });

--- a/packages/contentful-to-structured-text/package-lock.json
+++ b/packages/contentful-to-structured-text/package-lock.json
@@ -1,0 +1,39 @@
+{
+  "name": "datocms-contentful-to-structured-text",
+  "version": "1.0.14",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@contentful/rich-text-types": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-14.1.2.tgz",
+      "integrity": "sha512-XbgZ7op5uyYYszipgQg/bYobF4b+llXyTwS8hISRniQY9xKESz544eP2OGmRc4J3MHx29M7Vmx7TVA/IK65giQ=="
+    },
+    "datocms-structured-text-utils": {
+      "version": "1.0.14",
+      "requires": {
+        "lodash.flatten": "^4.4.0"
+      },
+      "dependencies": {
+        "@types/lodash": {
+          "version": "4.14.167",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.167.tgz",
+          "integrity": "sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw=="
+        },
+        "@types/lodash.flatten": {
+          "version": "4.4.6",
+          "resolved": "https://registry.npmjs.org/@types/lodash.flatten/-/lodash.flatten-4.4.6.tgz",
+          "integrity": "sha512-omCBl4M8EJSmf2DZqh4/zwjgXQpzC7YO/PXTcG8rI9r7xun8CohrHeNx8HZRkqWc61uJfIaZop9MwJEXPVssHw==",
+          "requires": {
+            "@types/lodash": "*"
+          }
+        },
+        "lodash.flatten": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+          "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+        }
+      }
+    }
+  }
+}

--- a/packages/contentful-to-structured-text/package.json
+++ b/packages/contentful-to-structured-text/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "datocms-contentful-to-structured-text",
+  "version": "1.0.14",
+  "description": "Convert Contentful Rich Text to a valid DatoCMS Structured Text `dast` document",
+  "keywords": [
+    "contentful",
+    "datocms",
+    "structured-text",
+    "dast",
+    "rich-text"
+  ],
+  "author": "Irene Oppo <i.oppo@datocms.com>",
+  "homepage": "https://github.com/datocms/structured-text/tree/master/packages/contentful-to-structured-text#readme",
+  "license": "MIT",
+  "main": "dist/lib/index.js",
+  "directories": {
+    "lib": "dist",
+    "test": "__tests__"
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/datocms/structured-text.git"
+  },
+  "scripts": {
+    "build": "tsc --module commonjs",
+    "prebuild": "rimraf dist"
+  },
+  "dependencies": {
+    "datocms-structured-text-utils": "^1.0.14"
+  },
+  "bugs": {
+    "url": "https://github.com/datocms/structured-text/issues"
+  }
+}

--- a/packages/contentful-to-structured-text/package.json
+++ b/packages/contentful-to-structured-text/package.json
@@ -29,6 +29,7 @@
     "prebuild": "rimraf dist"
   },
   "dependencies": {
+    "@contentful/rich-text-types": "^14.1.2",
     "datocms-structured-text-utils": "^1.0.14"
   },
   "bugs": {

--- a/packages/contentful-to-structured-text/src/handlers.ts
+++ b/packages/contentful-to-structured-text/src/handlers.ts
@@ -95,10 +95,6 @@ export const heading: Handler<ContentfulElementNode> = async function heading(
   });
 
   if (Array.isArray(children) && children.length) {
-    console.log('aaaaaaaa');
-    console.log(node);
-    console.log('aaaaaaaa');
-
     return isAllowedChild
       ? createNode('heading', {
           level: Number(node.nodeType.slice(-1)) || 1,
@@ -129,7 +125,7 @@ export const code: Handler<ContentfulElementNode> = async function code(
   const prefix =
     typeof context.codePrefix === 'string' ? context.codePrefix : 'language-';
   const isCode = true;
-  const children = node.children;
+  const children = node.content;
   let index = -1;
   let classList = null;
   let language = {};
@@ -266,13 +262,13 @@ export const link: Handler<ContentfulElementNode> = async function link(
   //
   // @TODO this is only checking for headings that are direct descendants of links.
   // Decide if it is worth looking deeper.
-  const wrapsHeadings = node.children.some(
+  const wrapsHeadings = node.content.some(
     (child) => child.type === 'element' && child.nodeType.startsWith('h'),
   );
   if (wrapsHeadings) {
     let i = 0;
     const splitChildren: ContentfulElementNode[] = [];
-    node.children.forEach((child) => {
+    node.content.forEach((child) => {
       if (child.type === 'element' && child.nodeType.startsWith('h')) {
         if (splitChildren.length > 0) {
           i++;
@@ -282,13 +278,13 @@ export const link: Handler<ContentfulElementNode> = async function link(
           children: [
             {
               ...node,
-              children: child.children,
+              children: child.content,
             },
           ],
         });
         i++;
       } else if (splitChildren[i]) {
-        splitChildren[i].children.push(child);
+        splitChildren[i].content.push(child);
       } else {
         splitChildren[i] = {
           ...node,
@@ -297,7 +293,7 @@ export const link: Handler<ContentfulElementNode> = async function link(
       }
     });
 
-    node.children = splitChildren;
+    node.content = splitChildren;
     isAllowedChild = false;
   }
 
@@ -312,7 +308,7 @@ export const link: Handler<ContentfulElementNode> = async function link(
     }
 
     const props = {
-      url: resolveUrl(context, node.properties.href),
+      url: resolveUrl(context, node.data.uri),
       children,
     };
 
@@ -382,34 +378,6 @@ export const italic = withMark('emphasis');
 export const underline = withMark('underline');
 export const strikethrough = withMark('strikethrough');
 export const highlight = withMark('highlight');
-
-export const head: Handler<ContentfulElementNode> = async function head(
-  createNode,
-  node,
-  context,
-) {
-  const baseElement = node.children.find((child) => child.nodeType === 'base');
-  if (baseElement) {
-    return context.handlers.base(createNode, baseElement, context);
-  } else {
-    return undefined;
-  }
-};
-
-export const base: Handler<ContentfulElementNode> = async function base(
-  createNode,
-  node,
-  context,
-) {
-  if (
-    !context.global.baseUrlFound &&
-    typeof node.properties === 'object' &&
-    node.properties.href
-  ) {
-    context.global.baseUrl = node.properties.href.replace(/\/$/, '');
-    context.global.baseUrlFound = true;
-  }
-};
 
 export const extractInlineStyles: Handler<ContentfulElementNode> = async function extractInlineStyles(
   createNode,

--- a/packages/contentful-to-structured-text/src/handlers.ts
+++ b/packages/contentful-to-structured-text/src/handlers.ts
@@ -95,9 +95,13 @@ export const heading: Handler<ContentfulElementNode> = async function heading(
   });
 
   if (Array.isArray(children) && children.length) {
+    console.log('aaaaaaaa');
+    console.log(node);
+    console.log('aaaaaaaa');
+
     return isAllowedChild
       ? createNode('heading', {
-          level: Number(node.tagName.charAt(1)) || 1,
+          level: Number(node.nodeType.slice(-1)) || 1,
           children,
         })
       : children;
@@ -208,7 +212,7 @@ export const list: Handler<ContentfulElementNode> = async function list(
   if (Array.isArray(children) && children.length) {
     return createNode('list', {
       children,
-      style: node.tagName === 'ol' ? 'numbered' : 'bulleted',
+      style: node.nodeType === 'ol' ? 'numbered' : 'bulleted',
     });
   }
   return undefined;
@@ -263,13 +267,13 @@ export const link: Handler<ContentfulElementNode> = async function link(
   // @TODO this is only checking for headings that are direct descendants of links.
   // Decide if it is worth looking deeper.
   const wrapsHeadings = node.children.some(
-    (child) => child.type === 'element' && child.tagName.startsWith('h'),
+    (child) => child.type === 'element' && child.nodeType.startsWith('h'),
   );
   if (wrapsHeadings) {
     let i = 0;
     const splitChildren: ContentfulElementNode[] = [];
     node.children.forEach((child) => {
-      if (child.type === 'element' && child.tagName.startsWith('h')) {
+      if (child.type === 'element' && child.nodeType.startsWith('h')) {
         if (splitChildren.length > 0) {
           i++;
         }
@@ -341,7 +345,7 @@ export const span: Handler<ContentfulTextNode> = async function span(
 ) {
   const marks = {};
 
-  const datoMarks = {
+  const datoToContentfulMarks = {
     bold: 'strong',
     italic: 'emphasis',
     underline: 'underline',
@@ -350,11 +354,11 @@ export const span: Handler<ContentfulTextNode> = async function span(
 
   if (Array.isArray(node.marks)) {
     const allowedMarks = node.marks.filter((mark) =>
-      context.allowedMarks.includes(datoMarks[mark]),
+      context.allowedMarks.includes(datoToContentfulMarks[mark]),
     );
 
     if (allowedMarks.length > 0) {
-      marks.marks = allowedMarks.map((m) => datoMarks[m]);
+      marks.marks = allowedMarks.map((m) => datoToContentfulMarks[m]);
     }
   }
 
@@ -384,7 +388,7 @@ export const head: Handler<ContentfulElementNode> = async function head(
   node,
   context,
 ) {
-  const baseElement = node.children.find((child) => child.tagName === 'base');
+  const baseElement = node.children.find((child) => child.nodeType === 'base');
   if (baseElement) {
     return context.handlers.base(createNode, baseElement, context);
   } else {

--- a/packages/contentful-to-structured-text/src/handlers.ts
+++ b/packages/contentful-to-structured-text/src/handlers.ts
@@ -18,13 +18,7 @@ import { wrap } from './wrap';
 
 import visitChildren from './visit-children';
 import { MetaEntry } from '../../utils/dist/types';
-
-const datoToContentfulMarks = {
-  bold: 'strong',
-  italic: 'emphasis',
-  underline: 'underline',
-  code: 'code',
-};
+import { datoToContentfulMarks } from './index';
 
 export const root: Handler<ContentfulRootNode> = async function root(
   createNode,

--- a/packages/contentful-to-structured-text/src/handlers.ts
+++ b/packages/contentful-to-structured-text/src/handlers.ts
@@ -68,18 +68,6 @@ export const span: Handler<ContentfulTextNode> = async function span(
     }
   }
 
-  const canBeCodeBlock =
-    marks.marks &&
-    marks.marks.includes('code') &&
-    allowedChildren[context.parentNodeType].includes('code') &&
-    context.allowedBlocks.includes('code');
-
-  if (canBeCodeBlock) {
-    return createNode('code', {
-      code: node.value,
-    });
-  }
-
   return createNode('span', {
     value: node.value,
     ...marks,
@@ -101,8 +89,21 @@ export const paragraph: Handler<ContentfulElementNode> = async function paragrap
   });
 
   if (Array.isArray(children) && children.length) {
+    // TODO: Code block gets created only if it's in root and is not inline
+    if (
+      children.length === 1 &&
+      children[0].marks &&
+      children[0].marks.length === 1 &&
+      children[0].marks.includes('code') &&
+      context.allowedBlocks.includes('code') &&
+      context.parentNode.nodeType === 'document'
+    ) {
+      return codeBlock(createNode, children[0]);
+    }
+
     return isAllowedChild ? createNode('paragraph', { children }) : children;
   }
+
   return undefined;
 };
 
@@ -191,6 +192,15 @@ export const list: Handler<ContentfulElementNode> = async function list(
     });
   }
   return undefined;
+};
+
+export const codeBlock: Handler<ContentfulElementNode> = async function codeBlock(
+  createNode,
+  node,
+) {
+  return createNode('code', {
+    code: node.value,
+  });
 };
 
 export const listItem: Handler<ContentfulElementNode> = async function listItem(

--- a/packages/contentful-to-structured-text/src/handlers.ts
+++ b/packages/contentful-to-structured-text/src/handlers.ts
@@ -52,6 +52,10 @@ export const paragraph: Handler<ContentfulElementNode> = async function paragrap
   node,
   context,
 ) {
+  console.log('-------------------');
+  console.log(node);
+  console.log('=----------node');
+
   const isAllowedChild = allowedChildren[context.parentNodeType].includes(
     'paragraph',
   );
@@ -163,7 +167,7 @@ export const code: Handler<ContentfulElementNode> = async function code(
 
   return createNode('code', {
     ...language,
-    code: String(wrapText(context, node)).replace(/\n+$/, ''),
+    code: String(node).replace(/\n+$/, ''),
   });
 };
 
@@ -333,6 +337,7 @@ export const link: Handler<ContentfulElementNode> = async function link(
   }
   return undefined;
 };
+
 export const span: Handler<ContentfulTextNode> = async function span(
   createNode,
   node,
@@ -349,8 +354,12 @@ export const span: Handler<ContentfulTextNode> = async function span(
     }
   }
 
+  console.log('=================');
+  console.log(node);
+  console.log('=================');
+
   return createNode('span', {
-    value: wrapText(context, node.value),
+    value: node.value,
     ...marks,
   });
 };
@@ -473,6 +482,7 @@ export function withMark(type: Mark): Handler<ContentfulElementNode> {
 }
 
 export const handlers = {
+  text: span,
   [BLOCKS.DOCUMENT]: root,
   [BLOCKS.PARAGRAPH]: paragraph,
   [BLOCKS.HEADING_1]: heading,
@@ -592,10 +602,6 @@ export const wrapListItems: Handler<ContentfulElementNode> = async function wrap
 
   return children;
 };
-
-export function wrapText(context: Context, value: string): string {
-  return context.wrapText ? value : value.replace(/\r?\n|\r/g, ' ');
-}
 
 export function resolveUrl(
   context: Context,

--- a/packages/contentful-to-structured-text/src/handlers.ts
+++ b/packages/contentful-to-structured-text/src/handlers.ts
@@ -1,0 +1,606 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+import convert from 'hast-util-is-element/convert';
+import toText from 'hast-util-to-text';
+import has from 'hast-util-has-property';
+import {
+  allowedChildren,
+  inlineNodeTypes,
+} from 'datocms-structured-text-utils';
+
+import {
+  Handler,
+  Mark,
+  Context,
+  HastNode,
+  HastTextNode,
+  HastElementNode,
+  HastRootNode,
+} from './types';
+
+import visitChildren from './visit-children';
+import { wrap } from './wrap';
+import { MetaEntry } from '../../utils/dist/types';
+
+export const root: Handler<HastRootNode> = async function root(
+  createNode,
+  node,
+  context,
+) {
+  let children = await visitChildren(createNode, node, {
+    ...context,
+    parentNodeType: 'root',
+  });
+
+  if (
+    Array.isArray(children) &&
+    children.some(
+      (child: HastNode) => child && !allowedChildren.root.includes(child.type),
+    )
+  ) {
+    children = wrap(children);
+  }
+
+  if (!Array.isArray(children) || children.length === 0) {
+    return null;
+  }
+
+  return createNode('root', {
+    children: Array.isArray(children) ? children : [],
+  });
+};
+
+export const paragraph: Handler<HastElementNode> = async function paragraph(
+  createNode,
+  node,
+  context,
+) {
+  const isAllowedChild = allowedChildren[context.parentNodeType].includes(
+    'paragraph',
+  );
+
+  const children = await visitChildren(createNode, node, {
+    ...context,
+    parentNodeType: isAllowedChild ? 'paragraph' : context.parentNodeType,
+  });
+
+  if (Array.isArray(children) && children.length) {
+    return isAllowedChild ? createNode('paragraph', { children }) : children;
+  }
+  return undefined;
+};
+
+export const thematicBreak: Handler<HastElementNode> = async function thematicBreak(
+  createNode,
+  node,
+  context,
+) {
+  const isAllowedChild = allowedChildren[context.parentNodeType].includes(
+    'thematicBreak',
+  );
+
+  return isAllowedChild ? createNode('thematicBreak', {}) : undefined;
+};
+
+export const heading: Handler<HastElementNode> = async function heading(
+  createNode,
+  node,
+  context,
+) {
+  const isAllowedChild =
+    allowedChildren[context.parentNodeType].includes('heading') &&
+    context.allowedBlocks.includes('heading');
+
+  const children = await visitChildren(createNode, node, {
+    ...context,
+    parentNodeType: isAllowedChild ? 'heading' : context.parentNodeType,
+    wrapText: isAllowedChild ? false : context.wrapText,
+  });
+
+  if (Array.isArray(children) && children.length) {
+    return isAllowedChild
+      ? createNode('heading', {
+          level: Number(node.tagName.charAt(1)) || 1,
+          children,
+        })
+      : children;
+  }
+  return undefined;
+};
+
+export const code: Handler<HastElementNode> = async function code(
+  createNode,
+  node,
+  context,
+) {
+  const isAllowedChild = allowedChildren[context.parentNodeType].includes(
+    'code',
+  );
+
+  if (!isAllowedChild) {
+    return inlineCode(createNode, node, context);
+  }
+
+  if (!context.allowedBlocks.includes('code')) {
+    return visitChildren(createNode, node, context);
+  }
+
+  const prefix =
+    typeof context.codePrefix === 'string' ? context.codePrefix : 'language-';
+  const isPre = convert('pre');
+  const isCode = convert('code');
+  const children = node.children;
+  let index = -1;
+  let classList = null;
+  let language = {};
+
+  if (isPre(node)) {
+    while (++index < children.length) {
+      if (
+        typeof children[index] === 'object' &&
+        isCode(children[index]) &&
+        has(children[index], 'className')
+      ) {
+        // error TS2339: Property 'properties' does not exist on type 'HastNode'.
+        //               Property 'properties' does not exist on type 'HastTextNode'
+        // isCode (convert) checks that the node is an element and therefore it'll have properties
+        // @ts-ignore
+        classList = children[index].properties.className;
+        break;
+      }
+    }
+  } else if (isCode(node) && has(node, 'className')) {
+    classList = node.properties.className;
+  }
+
+  if (Array.isArray(classList)) {
+    index = -1;
+
+    while (++index < classList.length) {
+      if (classList[index].slice(0, prefix.length) === prefix) {
+        language = { language: classList[index].slice(prefix.length) };
+        break;
+      }
+    }
+  }
+
+  return createNode('code', {
+    ...language,
+    code: String(wrapText(context, toText(node))).replace(/\n+$/, ''),
+  });
+};
+
+export const blockquote: Handler<HastElementNode> = async function blockquote(
+  createNode,
+  node,
+  context,
+) {
+  const isAllowedChild =
+    allowedChildren[context.parentNodeType].includes('blockquote') &&
+    context.allowedBlocks.includes('blockquote');
+
+  const children = await visitChildren(createNode, node, {
+    ...context,
+    parentNodeType: isAllowedChild ? 'blockquote' : context.parentNodeType,
+  });
+
+  if (Array.isArray(children) && children.length) {
+    return isAllowedChild
+      ? createNode('blockquote', { children: wrap(children) })
+      : children;
+  }
+  return undefined;
+};
+export const list: Handler<HastElementNode> = async function list(
+  createNode,
+  node,
+  context,
+) {
+  const isAllowedChild =
+    allowedChildren[context.parentNodeType].includes('list') &&
+    context.allowedBlocks.includes('list');
+
+  if (!isAllowedChild) {
+    return await visitChildren(createNode, node, context);
+  }
+
+  const children = await wrapListItems(createNode, node, {
+    ...context,
+    parentNodeType: 'list',
+  });
+
+  if (Array.isArray(children) && children.length) {
+    return createNode('list', {
+      children,
+      style: node.tagName === 'ol' ? 'numbered' : 'bulleted',
+    });
+  }
+  return undefined;
+};
+export const listItem: Handler<HastElementNode> = async function listItem(
+  createNode,
+  node,
+  context,
+) {
+  const isAllowedChild =
+    allowedChildren[context.parentNodeType].includes('listItem') &&
+    context.allowedBlocks.includes('list');
+
+  const children = await visitChildren(createNode, node, {
+    ...context,
+    parentNodeType: isAllowedChild ? 'listItem' : context.parentNodeType,
+  });
+
+  if (Array.isArray(children) && children.length) {
+    return isAllowedChild
+      ? createNode('listItem', {
+          children: wrap(children),
+        })
+      : children;
+  }
+  return undefined;
+};
+export const link: Handler<HastElementNode> = async function link(
+  createNode,
+  node,
+  context,
+) {
+  if (!context.allowedBlocks.includes('link')) {
+    return visitChildren(createNode, node, context);
+  }
+
+  let isAllowedChild = false;
+
+  if (allowedChildren[context.parentNodeType] === 'inlineNodes') {
+    isAllowedChild = inlineNodeTypes.includes('link');
+  } else if (Array.isArray(allowedChildren[context.parentNodeType])) {
+    isAllowedChild = allowedChildren[context.parentNodeType].includes('link');
+  }
+
+  if (!isAllowedChild) {
+    // Links that aren't inside of a allowedChildren context
+    // can still be valid `dast` nodes in the following contexts if wrapped.
+    const allowedChildrenWrapped = ['root', 'list', 'listItem'];
+    isAllowedChild = allowedChildrenWrapped.includes(context.parentNodeType);
+  }
+
+  // When a link wraps headings we try to preserve the heading by inverting the parent-child relationship.
+  // Essentially we tweak the nodes so that the heading wraps the link.
+  //
+  // @TODO this is only checking for headings that are direct descendants of links.
+  // Decide if it is worth looking deeper.
+  const wrapsHeadings = node.children.some(
+    (child) => child.type === 'element' && child.tagName.startsWith('h'),
+  );
+  if (wrapsHeadings) {
+    let i = 0;
+    const splitChildren: HastElementNode[] = [];
+    node.children.forEach((child) => {
+      if (child.type === 'element' && child.tagName.startsWith('h')) {
+        if (splitChildren.length > 0) {
+          i++;
+        }
+        splitChildren.push({
+          ...child,
+          children: [
+            {
+              ...node,
+              children: child.children,
+            },
+          ],
+        });
+        i++;
+      } else if (splitChildren[i]) {
+        splitChildren[i].children.push(child);
+      } else {
+        splitChildren[i] = {
+          ...node,
+          children: [child],
+        };
+      }
+    });
+
+    node.children = splitChildren;
+    isAllowedChild = false;
+  }
+
+  const children = await visitChildren(createNode, node, {
+    ...context,
+    parentNodeType: isAllowedChild ? 'link' : context.parentNodeType,
+  });
+
+  if (Array.isArray(children) && children.length) {
+    if (!isAllowedChild) {
+      return children;
+    }
+
+    const props = {
+      url: resolveUrl(context, node.properties.href),
+      children,
+    };
+
+    const meta: Array<MetaEntry> = [];
+
+    if (node.properties) {
+      ['target', 'rel', 'title'].forEach((attr) => {
+        const value = Array.isArray(node.properties[attr])
+          ? node.properties[attr].join(' ')
+          : node.properties[attr];
+        if (value) {
+          meta.push({ id: attr, value });
+        }
+      });
+    }
+
+    if (meta.length > 0) {
+      props.meta = meta;
+    }
+
+    return createNode('link', props);
+  }
+  return undefined;
+};
+export const span: Handler<HastTextNode> = async function span(
+  createNode,
+  node,
+  context,
+) {
+  const marks = {};
+
+  if (Array.isArray(context.marks)) {
+    const allowedMarks = context.marks.filter((mark) =>
+      context.allowedMarks.includes(mark),
+    );
+    if (allowedMarks.length > 0) {
+      marks.marks = allowedMarks;
+    }
+  }
+
+  return createNode('span', {
+    value: wrapText(context, node.value),
+    ...marks,
+  });
+};
+
+export const newLine: Handler<HastTextNode> = async function newLine(
+  createNode,
+) {
+  return createNode('span', {
+    value: '\n',
+  });
+};
+
+export const inlineCode = withMark('code');
+export const strong = withMark('strong');
+export const italic = withMark('emphasis');
+export const underline = withMark('underline');
+export const strikethrough = withMark('strikethrough');
+export const highlight = withMark('highlight');
+
+export const head: Handler<HastElementNode> = async function head(
+  createNode,
+  node,
+  context,
+) {
+  const baseElement = node.children.find((child) => child.tagName === 'base');
+  if (baseElement) {
+    return context.handlers.base(createNode, baseElement, context);
+  } else {
+    return undefined;
+  }
+};
+
+export const base: Handler<HastElementNode> = async function base(
+  createNode,
+  node,
+  context,
+) {
+  if (
+    !context.global.baseUrlFound &&
+    typeof node.properties === 'object' &&
+    node.properties.href
+  ) {
+    context.global.baseUrl = node.properties.href.replace(/\/$/, '');
+    context.global.baseUrlFound = true;
+  }
+};
+
+export const extractInlineStyles: Handler<HastElementNode> = async function extractInlineStyles(
+  createNode,
+  node,
+  context,
+) {
+  let marks = { marks: Array.isArray(context.marks) ? context.marks : [] };
+  if (node.properties && typeof node.properties.style === 'string') {
+    const newMarks = [];
+    node.properties.style.split(';').forEach((declaration) => {
+      const [firstChunk, ...otherChunks] = declaration.split(':');
+      const prop = firstChunk.trim();
+      const value = otherChunks.join(':').trim();
+      switch (prop) {
+        case 'font-weight':
+          if (value === 'bold' || Number(value) > 400) {
+            newMarks.push('strong');
+          }
+          break;
+        case 'font-style':
+          if (value === 'italic') {
+            newMarks.push('emphasis');
+          }
+          break;
+        case 'text-decoration':
+          if (value === 'underline') {
+            newMarks.push('underline');
+          }
+          break;
+        default:
+          break;
+      }
+    });
+    if (newMarks.length > 0) {
+      marks.marks = marks.marks.concat(
+        newMarks.filter(
+          (mark) =>
+            !marks.marks.includes(mark) && context.allowedMarks.includes(mark),
+        ),
+      );
+    }
+  }
+  if (marks.marks.length === 0) {
+    marks = {};
+  }
+  return visitChildren(createNode, node, {
+    ...context,
+    ...marks,
+  });
+};
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function,  @typescript-eslint/explicit-module-boundary-types
+export async function noop() {}
+
+export function withMark(type: Mark): Handler<HastElementNode> {
+  return function markHandler(createNode, node, context) {
+    if (!context.allowedMarks.includes(type)) {
+      return visitChildren(createNode, node, context);
+    }
+
+    let marks = { marks: [type] };
+    if (Array.isArray(context.marks)) {
+      marks = {
+        marks: context.marks.includes(type)
+          ? context.marks
+          : context.marks.concat([type]),
+      };
+    }
+    return visitChildren(createNode, node, {
+      ...context,
+      ...marks,
+    });
+  };
+}
+
+export const handlers = {
+  root: root,
+
+  p: paragraph,
+  summary: paragraph,
+
+  h1: heading,
+  h2: heading,
+  h3: heading,
+  h4: heading,
+  h5: heading,
+  h6: heading,
+
+  ul: list,
+  ol: list,
+  dir: list,
+
+  dt: listItem,
+  dd: listItem,
+  li: listItem,
+
+  listing: code,
+  plaintext: code,
+  pre: code,
+  xmp: code,
+
+  blockquote: blockquote,
+
+  a: link,
+
+  code: code,
+  kbd: code,
+  samp: code,
+  tt: code,
+  var: code,
+
+  strong: strong,
+  b: strong,
+
+  em: italic,
+  i: italic,
+
+  u: underline,
+
+  strike: strikethrough,
+  s: strikethrough,
+
+  mark: highlight,
+
+  base: base,
+
+  span: extractInlineStyles,
+  text: span,
+  br: newLine,
+
+  hr: thematicBreak,
+
+  head: head,
+  comment: noop,
+  script: noop,
+  style: noop,
+  title: noop,
+  video: noop,
+  audio: noop,
+  embed: noop,
+  iframe: noop,
+};
+
+export const wrapListItems: Handler<HastElementNode> = async function wrapListItems(
+  createNode,
+  node,
+  context,
+) {
+  const children = await visitChildren(createNode, node, context);
+
+  if (!Array.isArray(children)) {
+    return [];
+  }
+
+  let index = -1;
+  while (++index < children.length) {
+    if (
+      typeof children[index] !== 'undefined' &&
+      children[index].type !== 'listItem'
+    ) {
+      children[index] = {
+        type: 'listItem',
+        children: [
+          allowedChildren.listItem.includes(children[index].type)
+            ? children[index]
+            : createNode('paragraph', { children: [children[index]] }),
+        ],
+      };
+    }
+  }
+
+  return children;
+};
+
+export function wrapText(context: Context, value: string): string {
+  return context.wrapText ? value : value.replace(/\r?\n|\r/g, ' ');
+}
+
+export function resolveUrl(
+  context: Context,
+  url: string | null | undefined,
+): string {
+  if (url === null || url === undefined) {
+    return '';
+  }
+
+  if (context.global.baseUrl && typeof URL !== 'undefined') {
+    const isRelative = /^\.?\//.test(url);
+    const parsed = new URL(url, context.global.baseUrl);
+    if (isRelative) {
+      const parsedBase = new URL(context.global.baseUrl);
+      if (!parsed.pathname.startsWith(parsedBase.pathname)) {
+        parsed.pathname = `${parsedBase.pathname}${parsed.pathname}`;
+      }
+    }
+    return parsed.toString();
+  }
+
+  return url;
+}

--- a/packages/contentful-to-structured-text/src/handlers.ts
+++ b/packages/contentful-to-structured-text/src/handlers.ts
@@ -91,7 +91,7 @@ export const paragraph: Handler<ContentfulParagraph> = async function paragraph(
   });
 
   if (Array.isArray(children) && children.length) {
-    // TODO: Code block gets created only if it's in root and is not inline
+    // Code block gets created only if in root and not inline
     if (
       children.length === 1 &&
       children[0].marks &&
@@ -191,6 +191,7 @@ export const list: Handler<ContentfulList> = async function list(
       style: node.nodeType === 'ordered-list' ? 'numbered' : 'bulleted',
     });
   }
+
   return undefined;
 };
 
@@ -213,6 +214,7 @@ export const listItem: Handler<ContentfulListItem> = async function listItem(
       ? createNode('listItem', { children: wrap(children) })
       : children;
   }
+
   return undefined;
 };
 
@@ -331,12 +333,14 @@ export function resolveUrl(
   if (context.global.baseUrl && typeof URL !== 'undefined') {
     const isRelative = /^\.?\//.test(url);
     const parsed = new URL(url, context.global.baseUrl);
+
     if (isRelative) {
       const parsedBase = new URL(context.global.baseUrl);
       if (!parsed.pathname.startsWith(parsedBase.pathname)) {
         parsed.pathname = `${parsedBase.pathname}${parsed.pathname}`;
       }
     }
+
     return parsed.toString();
   }
 

--- a/packages/contentful-to-structured-text/src/handlers.ts
+++ b/packages/contentful-to-structured-text/src/handlers.ts
@@ -35,8 +35,11 @@ export const root: Handler<ContentfulRootNode> = async function root(
     parentNodeType: 'root',
   });
 
+  if (!Array.isArray(children) || children.length === 0) {
+    return null;
+  }
+
   if (
-    Array.isArray(children) &&
     children.some(
       (child: ContentfulNode) =>
         child && !allowedChildren.root.includes(child.type),
@@ -45,13 +48,7 @@ export const root: Handler<ContentfulRootNode> = async function root(
     children = wrap(children);
   }
 
-  if (!Array.isArray(children) || children.length === 0) {
-    return null;
-  }
-
-  return createNode('root', {
-    children: Array.isArray(children) ? children : [],
-  });
+  return createNode('root', { children });
 };
 
 export const span: Handler<ContentfulTextNode> = async function span(

--- a/packages/contentful-to-structured-text/src/handlers.ts
+++ b/packages/contentful-to-structured-text/src/handlers.ts
@@ -52,10 +52,6 @@ export const paragraph: Handler<ContentfulElementNode> = async function paragrap
   node,
   context,
 ) {
-  console.log('-------------------');
-  console.log(node);
-  console.log('=----------node');
-
   const isAllowedChild = allowedChildren[context.parentNodeType].includes(
     'paragraph',
   );
@@ -345,18 +341,22 @@ export const span: Handler<ContentfulTextNode> = async function span(
 ) {
   const marks = {};
 
-  if (Array.isArray(context.marks)) {
-    const allowedMarks = context.marks.filter((mark) =>
-      context.allowedMarks.includes(mark),
+  const datoMarks = {
+    bold: 'strong',
+    italic: 'emphasis',
+    underline: 'underline',
+    code: 'code',
+  };
+
+  if (Array.isArray(node.marks)) {
+    const allowedMarks = node.marks.filter((mark) =>
+      context.allowedMarks.includes(datoMarks[mark]),
     );
+
     if (allowedMarks.length > 0) {
-      marks.marks = allowedMarks;
+      marks.marks = allowedMarks.map((m) => datoMarks[m]);
     }
   }
-
-  console.log('=================');
-  console.log(node);
-  console.log('=================');
 
   return createNode('span', {
     value: node.value,

--- a/packages/contentful-to-structured-text/src/handlers.ts
+++ b/packages/contentful-to-structured-text/src/handlers.ts
@@ -164,10 +164,9 @@ export const blockquote: Handler<ContentfulQuote> = async function blockquote(
   });
 
   if (Array.isArray(children) && children.length) {
-    return isAllowedChild
-      ? createNode('blockquote', { children: wrap(children) })
-      : children;
+    return isAllowedChild ? createNode('blockquote', { children }) : children;
   }
+
   return undefined;
 };
 

--- a/packages/contentful-to-structured-text/src/handlers.ts
+++ b/packages/contentful-to-structured-text/src/handlers.ts
@@ -14,6 +14,7 @@ import {
   ContentfulElementNode,
   ContentfulRootNode,
 } from './types';
+import { wrap } from './wrap';
 
 import visitChildren from './visit-children';
 import { MetaEntry } from '../../utils/dist/types';
@@ -28,15 +29,15 @@ export const root: Handler<ContentfulRootNode> = async function root(
     parentNodeType: 'root',
   });
 
-  // if (
-  //   Array.isArray(children) &&
-  //   children.some(
-  //     (child: ContentfulNode) =>
-  //       child && !allowedChildren.root.includes(child.type),
-  //   )
-  // ) {
-  //   children = wrap(children);
-  // }
+  if (
+    Array.isArray(children) &&
+    children.some(
+      (child: ContentfulNode) =>
+        child && !allowedChildren.root.includes(child.type),
+    )
+  ) {
+    children = wrap(children);
+  }
 
   if (!Array.isArray(children) || children.length === 0) {
     return null;
@@ -182,8 +183,9 @@ export const blockquote: Handler<ContentfulElementNode> = async function blockqu
   });
 
   if (Array.isArray(children) && children.length) {
-    // ? createNode('blockquote', { children: wrap(children) })
-    return isAllowedChild ? createNode('blockquote', { children }) : children;
+    return isAllowedChild
+      ? createNode('blockquote', { children: wrap(children) })
+      : children;
   }
   return undefined;
 };
@@ -228,8 +230,9 @@ export const listItem: Handler<ContentfulElementNode> = async function listItem(
   });
 
   if (Array.isArray(children) && children.length) {
-    // children: wrap(children),
-    return isAllowedChild ? createNode('listItem', { children }) : children;
+    return isAllowedChild
+      ? createNode('listItem', { children: wrap(children) })
+      : children;
   }
   return undefined;
 };

--- a/packages/contentful-to-structured-text/src/handlers.ts
+++ b/packages/contentful-to-structured-text/src/handlers.ts
@@ -348,10 +348,12 @@ export const span: Handler<ContentfulTextNode> = async function span(
     code: 'code',
   };
 
-  if (Array.isArray(node.marks)) {
-    const allowedMarks = node.marks.filter((mark) =>
-      context.allowedMarks.includes(datoToContentfulMarks[mark]),
-    );
+  if (Array.isArray(node.marks) && node.marks.length > 0) {
+    const allowedMarks = node.marks
+      .map((m) => m.type)
+      .filter((mark) =>
+        context.allowedMarks.includes(datoToContentfulMarks[mark]),
+      );
 
     if (allowedMarks.length > 0) {
       marks.marks = allowedMarks.map((m) => datoToContentfulMarks[m]);

--- a/packages/contentful-to-structured-text/src/handlers.ts
+++ b/packages/contentful-to-structured-text/src/handlers.ts
@@ -193,7 +193,7 @@ export const list: Handler<ContentfulElementNode> = async function list(
   if (Array.isArray(children) && children.length) {
     return createNode('list', {
       children,
-      style: node.nodeType === 'ol' ? 'numbered' : 'bulleted',
+      style: node.nodeType === 'ordered-list' ? 'numbered' : 'bulleted',
     });
   }
   return undefined;

--- a/packages/contentful-to-structured-text/src/index.ts
+++ b/packages/contentful-to-structured-text/src/index.ts
@@ -15,9 +15,9 @@ import {
   LinkType,
   ListType,
 } from 'datocms-structured-text-utils';
-import { MARKS } from '@contentful/rich-text-types';
+import { MARKS, Mark as ContentfulMark } from '@contentful/rich-text-types';
 
-export const datoToContentfulMarks = {
+export const datoToContentfulMarks: Record<ContentfulMark, Mark> = {
   [MARKS.BOLD]: 'strong',
   [MARKS.ITALIC]: 'emphasis',
   [MARKS.UNDERLINE]: 'underline',
@@ -41,10 +41,6 @@ export async function richTextToStructuredText(
     props.type = type;
     return props;
   };
-
-  if (typeof options.preprocess === 'function') {
-    options.preprocess(tree);
-  }
 
   const rootNode = await visitNode(createNode, tree, {
     parentNodeType: 'root',

--- a/packages/contentful-to-structured-text/src/index.ts
+++ b/packages/contentful-to-structured-text/src/index.ts
@@ -48,7 +48,6 @@ export async function richTextToStructuredText(
     parentNode: null,
     defaultHandlers: handlers,
     handlers: Object.assign({}, handlers, options.handlers || {}),
-    wrapText: true,
     allowedBlocks: Array.isArray(options.allowedBlocks)
       ? options.allowedBlocks
       : ['blockquote', 'code', 'heading', 'link', 'list'],

--- a/packages/contentful-to-structured-text/src/index.ts
+++ b/packages/contentful-to-structured-text/src/index.ts
@@ -1,0 +1,9 @@
+import { isBlock } from 'datocms-structured-text-utils';
+
+export async function richTextToStructuredText(): Promise<boolean> {
+  if (isBlock({ type: 'blockquote', children: [] })) {
+    return true;
+  }
+
+  return false;
+}

--- a/packages/contentful-to-structured-text/src/index.ts
+++ b/packages/contentful-to-structured-text/src/index.ts
@@ -55,7 +55,6 @@ export async function richTextToStructuredText(
       : Object.values(datoToContentfulMarks),
     global: {
       baseUrl: null,
-      baseUrlFound: false,
       ...(options.shared || {}),
     },
   });

--- a/packages/contentful-to-structured-text/src/index.ts
+++ b/packages/contentful-to-structured-text/src/index.ts
@@ -1,9 +1,75 @@
-import { isBlock } from 'datocms-structured-text-utils';
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
 
-export async function richTextToStructuredText(): Promise<boolean> {
-  if (isBlock({ type: 'blockquote', children: [] })) {
-    return true;
+// @ts-ignore
+import minify from 'rehype-minify-whitespace';
+
+import { CreateNodeFunction, ContentfulRootNode } from './types';
+import visitNode from './visit-node';
+import visitChildren from './visit-children';
+import { handlers } from './handlers';
+import {
+  Document,
+  allowedMarks,
+  Mark,
+  BlockquoteType,
+  CodeType,
+  HeadingType,
+  LinkType,
+  ListType,
+} from 'datocms-structured-text-utils';
+
+export type Options = Partial<{
+  newlines: boolean;
+  handlers: Record<string, CreateNodeFunction>;
+  allowedBlocks: Array<
+    BlockquoteType | CodeType | HeadingType | LinkType | ListType
+  >;
+  allowedMarks: Mark[];
+}>;
+
+export async function richTextToStructuredText(
+  tree: ContentfulRootNode,
+  options: Options = {},
+): Promise<Document | null> {
+  minify({ newlines: options.newlines === true })(tree);
+
+  const createNode: CreateNodeFunction = (type, props) => {
+    props.type = type;
+    return props;
+  };
+
+  if (typeof options.preprocess === 'function') {
+    options.preprocess(tree);
   }
 
-  return false;
+  const rootNode = await visitNode(createNode, tree, {
+    parentNodeType: 'root',
+    parentNode: null,
+    defaultHandlers: handlers,
+    handlers: Object.assign({}, handlers, options.handlers || {}),
+    wrapText: true,
+    allowedBlocks: Array.isArray(options.allowedBlocks)
+      ? options.allowedBlocks
+      : ['blockquote', 'code', 'heading', 'link', 'list'],
+    allowedMarks: Array.isArray(options.allowedMarks)
+      ? options.allowedMarks
+      : allowedMarks,
+    global: {
+      baseUrl: null,
+      baseUrlFound: false,
+      ...(options.shared || {}),
+    },
+  });
+
+  if (rootNode) {
+    return {
+      schema: 'dast',
+      document: rootNode,
+    };
+  }
+
+  return null;
 }
+
+export { visitNode, visitChildren };

--- a/packages/contentful-to-structured-text/src/index.ts
+++ b/packages/contentful-to-structured-text/src/index.ts
@@ -15,6 +15,14 @@ import {
   LinkType,
   ListType,
 } from 'datocms-structured-text-utils';
+import { MARKS } from '@contentful/rich-text-types';
+
+export const datoToContentfulMarks = {
+  [MARKS.BOLD]: 'strong',
+  [MARKS.ITALIC]: 'emphasis',
+  [MARKS.UNDERLINE]: 'underline',
+  [MARKS.CODE]: 'code',
+};
 
 export type Options = Partial<{
   newlines: boolean;
@@ -38,13 +46,6 @@ export async function richTextToStructuredText(
     options.preprocess(tree);
   }
 
-  const contentfulAllowedMarks: Mark[] = [
-    'strong',
-    'emphasis',
-    'underline',
-    'code',
-  ];
-
   const rootNode = await visitNode(createNode, tree, {
     parentNodeType: 'root',
     parentNode: null,
@@ -55,7 +56,7 @@ export async function richTextToStructuredText(
       : ['blockquote', 'code', 'heading', 'link', 'list'],
     allowedMarks: Array.isArray(options.allowedMarks)
       ? options.allowedMarks
-      : contentfulAllowedMarks,
+      : Object.values(datoToContentfulMarks),
     global: {
       baseUrl: null,
       baseUrlFound: false,

--- a/packages/contentful-to-structured-text/src/index.ts
+++ b/packages/contentful-to-structured-text/src/index.ts
@@ -2,8 +2,6 @@
 // @ts-nocheck
 
 // @ts-ignore
-import minify from 'rehype-minify-whitespace';
-
 import { CreateNodeFunction, ContentfulRootNode } from './types';
 import visitNode from './visit-node';
 import visitChildren from './visit-children';
@@ -32,8 +30,6 @@ export async function richTextToStructuredText(
   tree: ContentfulRootNode,
   options: Options = {},
 ): Promise<Document | null> {
-  minify({ newlines: options.newlines === true })(tree);
-
   const createNode: CreateNodeFunction = (type, props) => {
     props.type = type;
     return props;

--- a/packages/contentful-to-structured-text/src/index.ts
+++ b/packages/contentful-to-structured-text/src/index.ts
@@ -8,7 +8,6 @@ import visitChildren from './visit-children';
 import { handlers } from './handlers';
 import {
   Document,
-  allowedMarks,
   Mark,
   BlockquoteType,
   CodeType,
@@ -39,6 +38,13 @@ export async function richTextToStructuredText(
     options.preprocess(tree);
   }
 
+  const contentfulAllowedMarks: Mark[] = [
+    'strong',
+    'emphasis',
+    'underline',
+    'code',
+  ];
+
   const rootNode = await visitNode(createNode, tree, {
     parentNodeType: 'root',
     parentNode: null,
@@ -49,7 +55,7 @@ export async function richTextToStructuredText(
       : ['blockquote', 'code', 'heading', 'link', 'list'],
     allowedMarks: Array.isArray(options.allowedMarks)
       ? options.allowedMarks
-      : allowedMarks,
+      : contentfulAllowedMarks,
     global: {
       baseUrl: null,
       baseUrlFound: false,

--- a/packages/contentful-to-structured-text/src/types.ts
+++ b/packages/contentful-to-structured-text/src/types.ts
@@ -1,6 +1,6 @@
 import { Node, Root, NodeType, Mark } from 'datocms-structured-text-utils';
 import {
-  Block as ContentfulBlock,
+  Block as ContentfulElementNode,
   Inline as ContentfulInline,
   Document as ContentfulDocument,
   Text as ContentfulText,
@@ -10,7 +10,7 @@ import {
 
 export { Node, Root, NodeType, Mark };
 export {
-  ContentfulBlock,
+  ContentfulElementNode,
   ContentfulInline,
   ContentfulDocument,
   ContentfulText,
@@ -80,5 +80,5 @@ export type Handler<ContentfulNodeType> = (
 
 export type ContentfulNode =
   | ContentfulText
-  | ContentfulBlock
+  | ContentfulElementNode
   | ContentfulRootNode;

--- a/packages/contentful-to-structured-text/src/types.ts
+++ b/packages/contentful-to-structured-text/src/types.ts
@@ -1,20 +1,36 @@
 import { Node, Root, NodeType, Mark } from 'datocms-structured-text-utils';
+
 import {
   Block as ContentfulBlock,
   Inline as ContentfulInline,
-  Document as ContentfulDocument,
-  Text as ContentfulText,
-  Mark as ContentfulMark,
+  Paragraph as ContentfulParagraph,
+  Text as ContentfulTextNode,
   TopLevelBlock as ContentfulRootNode,
+  Quote as ContentfulQuote,
+  Hr as ContentfulHr,
+  OrderedList as ContentfulOrderedList,
+  UnorderedList as ContentfulUnorderedList,
+  ListItem as ContentfulListItem,
+  Hyperlink as ContentfulHyperLink,
+  Heading1,
+  Heading2,
+  Heading3,
+  Heading4,
+  Heading5,
+  Heading6,
 } from '@contentful/rich-text-types';
 
 export { Node, Root, NodeType, Mark };
+
 export {
   ContentfulInline,
-  ContentfulDocument,
-  ContentfulText,
-  ContentfulMark,
+  ContentfulTextNode,
   ContentfulRootNode,
+  ContentfulParagraph,
+  ContentfulQuote,
+  ContentfulHr,
+  ContentfulListItem,
+  ContentfulHyperLink,
 };
 
 export type CreateNodeFunction = (
@@ -64,22 +80,20 @@ export type Handler<ContentfulNodeType> = (
   | Promise<Node | Array<Node> | void>
   | Array<Promise<Node | Array<Node> | void>>;
 
-// export interface HastProperties {
-//   className?: string[];
-//   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-//   [key: string]: any;
-// }
-
-// export interface RichTextElementNode {
-//   type: 'element';
-//   tagName: string;
-//   properties?: HastProperties;
-//   children?: ContentfulNode[];
-// }
-
 export type ContentfulNode =
-  | ContentfulText
-  | ContentfulElementNode
-  | ContentfulRootNode;
+  | ContentfulRootNode
+  | ContentfulTextNode
+  | ContentfulBlock
+  | ContentfulInline;
 
-export type ContentfulElementNode = ContentfulBlock | ContentfulInline;
+export type ContentfulHeading =
+  | Heading1
+  | Heading2
+  | Heading3
+  | Heading4
+  | Heading5
+  | Heading6;
+
+export type ContentfulNodeWithContent = ContentfulBlock | ContentfulInline;
+
+export type ContentfulList = ContentfulOrderedList | ContentfulUnorderedList;

--- a/packages/contentful-to-structured-text/src/types.ts
+++ b/packages/contentful-to-structured-text/src/types.ts
@@ -39,19 +39,14 @@ export type CreateNodeFunction = (
 ) => Node;
 
 export interface GlobalContext {
-  /**
-   * Whether the library has found a <base> tag or should not look further.
-   * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
-   */
-  baseUrlFound?: boolean;
-  /** <base> tag url. This is used for resolving relative URLs. */
+  /** This is used for resolving relative URLs. */
   baseUrl?: string;
 }
 
 export interface Context {
   /** The parent `dast` node type. */
   parentNodeType: NodeType;
-  /** The parent `hast` node. */
+  /** The parent Contentful node. */
   parentNode: ContentfulNode;
   /** A reference to the current handlers - merged default + user handlers. */
   handlers: Record<string, Handler<unknown>>;
@@ -59,13 +54,6 @@ export interface Context {
   defaultHandlers: Record<string, Handler<unknown>>;
   /** Marks for span nodes. */
   marks?: Mark[];
-  /**
-   * Prefix for language detection in code blocks.
-   *
-   * Detection is done on a class name eg class="language-html".
-   * Default is `language-`.
-   */
-  codePrefix?: string;
   /** Properties in this object are avaliable to every handler as Context
    * is not deeply cloned.
    */

--- a/packages/contentful-to-structured-text/src/types.ts
+++ b/packages/contentful-to-structured-text/src/types.ts
@@ -1,6 +1,6 @@
 import { Node, Root, NodeType, Mark } from 'datocms-structured-text-utils';
 import {
-  Block as ContentfulElementNode,
+  Block as ContentfulBlock,
   Inline as ContentfulInline,
   Document as ContentfulDocument,
   Text as ContentfulText,
@@ -10,7 +10,6 @@ import {
 
 export { Node, Root, NodeType, Mark };
 export {
-  ContentfulElementNode,
   ContentfulInline,
   ContentfulDocument,
   ContentfulText,
@@ -82,3 +81,5 @@ export type ContentfulNode =
   | ContentfulText
   | ContentfulElementNode
   | ContentfulRootNode;
+
+export type ContentfulElementNode = ContentfulBlock | ContentfulInline;

--- a/packages/contentful-to-structured-text/src/types.ts
+++ b/packages/contentful-to-structured-text/src/types.ts
@@ -1,0 +1,81 @@
+import { Node, Root, NodeType, Mark } from 'datocms-structured-text-utils';
+
+export { Node, Root, NodeType, Mark };
+
+export type CreateNodeFunction = (
+  type: NodeType,
+  props: Omit<Node, 'type'>,
+) => Node;
+
+export interface GlobalContext {
+  /**
+   * Whether the library has found a <base> tag or should not look further.
+   * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
+   */
+  baseUrlFound?: boolean;
+  /** <base> tag url. This is used for resolving relative URLs. */
+  baseUrl?: string;
+}
+
+export interface Context {
+  /** The parent `dast` node type. */
+  parentNodeType: NodeType;
+  /** The parent `hast` node. */
+  parentNode: RichTextNode;
+  /** A reference to the current handlers - merged default + user handlers. */
+  handlers: Record<string, Handler<unknown>>;
+  /** A reference to the default handlers record (map). */
+  defaultHandlers: Record<string, Handler<unknown>>;
+  /** true if the content can include newlines, and false if not (such as in headings). */
+  wrapText: boolean;
+  /** Marks for span nodes. */
+  marks?: Mark[];
+  /**
+   * Prefix for language detection in code blocks.
+   *
+   * Detection is done on a class name eg class="language-html".
+   * Default is `language-`.
+   */
+  codePrefix?: string;
+  /** Properties in this object are avaliable to every handler as Context
+   * is not deeply cloned.
+   */
+  global: GlobalContext;
+}
+
+export type Handler<RichTextNodeType> = (
+  createNodeFunction: CreateNodeFunction,
+  node: RichTextNodeType,
+  context: Context,
+) =>
+  | Promise<Node | Array<Node> | void>
+  | Array<Promise<Node | Array<Node> | void>>;
+
+export interface HastProperties {
+  className?: string[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export interface RichTextTextNode {
+  type: 'text';
+  value: string;
+}
+
+export interface RichTextElementNode {
+  type: 'element';
+  tagName: string;
+  properties?: HastProperties;
+  children?: RichTextNode[];
+}
+
+export interface RichTextRootNode {
+  nodeType: 'document';
+  data: {};
+  content?: RichTextNode[];
+}
+
+export type RichTextNode =
+  | RichTextTextNode
+  | RichTextElementNode
+  | RichTextRootNode;

--- a/packages/contentful-to-structured-text/src/types.ts
+++ b/packages/contentful-to-structured-text/src/types.ts
@@ -1,6 +1,22 @@
 import { Node, Root, NodeType, Mark } from 'datocms-structured-text-utils';
+import {
+  Block as ContentfulBlock,
+  Inline as ContentfulInline,
+  Document as ContentfulDocument,
+  Text as ContentfulText,
+  Mark as ContentfulMark,
+  TopLevelBlock as ContentfulRootNode,
+} from '@contentful/rich-text-types';
 
 export { Node, Root, NodeType, Mark };
+export {
+  ContentfulBlock,
+  ContentfulInline,
+  ContentfulDocument,
+  ContentfulText,
+  ContentfulMark,
+  ContentfulRootNode,
+};
 
 export type CreateNodeFunction = (
   type: NodeType,
@@ -21,13 +37,11 @@ export interface Context {
   /** The parent `dast` node type. */
   parentNodeType: NodeType;
   /** The parent `hast` node. */
-  parentNode: RichTextNode;
+  parentNode: ContentfulNode;
   /** A reference to the current handlers - merged default + user handlers. */
   handlers: Record<string, Handler<unknown>>;
   /** A reference to the default handlers record (map). */
   defaultHandlers: Record<string, Handler<unknown>>;
-  /** true if the content can include newlines, and false if not (such as in headings). */
-  wrapText: boolean;
   /** Marks for span nodes. */
   marks?: Mark[];
   /**
@@ -43,39 +57,28 @@ export interface Context {
   global: GlobalContext;
 }
 
-export type Handler<RichTextNodeType> = (
+export type Handler<ContentfulNodeType> = (
   createNodeFunction: CreateNodeFunction,
-  node: RichTextNodeType,
+  node: ContentfulNodeType,
   context: Context,
 ) =>
   | Promise<Node | Array<Node> | void>
   | Array<Promise<Node | Array<Node> | void>>;
 
-export interface HastProperties {
-  className?: string[];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
-}
+// export interface HastProperties {
+//   className?: string[];
+//   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+//   [key: string]: any;
+// }
 
-export interface RichTextTextNode {
-  type: 'text';
-  value: string;
-}
+// export interface RichTextElementNode {
+//   type: 'element';
+//   tagName: string;
+//   properties?: HastProperties;
+//   children?: ContentfulNode[];
+// }
 
-export interface RichTextElementNode {
-  type: 'element';
-  tagName: string;
-  properties?: HastProperties;
-  children?: RichTextNode[];
-}
-
-export interface RichTextRootNode {
-  nodeType: 'document';
-  data: {};
-  content?: RichTextNode[];
-}
-
-export type RichTextNode =
-  | RichTextTextNode
-  | RichTextElementNode
-  | RichTextRootNode;
+export type ContentfulNode =
+  | ContentfulText
+  | ContentfulBlock
+  | ContentfulRootNode;

--- a/packages/contentful-to-structured-text/src/visit-children.ts
+++ b/packages/contentful-to-structured-text/src/visit-children.ts
@@ -1,0 +1,37 @@
+import { Handler, Node, HastNode, HastElementNode } from './types';
+import visitNode from './visit-node';
+
+// visitChildren() is for visiting all the children of a node
+export default (async function visitChildren(createNode, parentNode, context) {
+  const nodes: HastNode[] = Array.isArray(parentNode.children)
+    ? parentNode.children
+    : [];
+  let values: Node[] = [];
+  let index = -1;
+  let result;
+
+  while (++index < nodes.length) {
+    result = (await visitNode(createNode, nodes[index], {
+      ...context,
+      parentNode,
+    })) as Node | Array<Node | Promise<Node>> | void;
+
+    if (result) {
+      if (Array.isArray(result)) {
+        result = (await Promise.all(
+          result.map(
+            (nodeOrPromise: Node | Promise<Node>): Promise<Node> => {
+              if (nodeOrPromise instanceof Promise) {
+                return nodeOrPromise;
+              }
+              return Promise.resolve(nodeOrPromise);
+            },
+          ),
+        )) as Array<Node>;
+      }
+      values = values.concat(result);
+    }
+  }
+
+  return values;
+} as Handler<HastElementNode>);

--- a/packages/contentful-to-structured-text/src/visit-children.ts
+++ b/packages/contentful-to-structured-text/src/visit-children.ts
@@ -3,8 +3,8 @@ import visitNode from './visit-node';
 
 // visitChildren() is for visiting all the children of a node
 export default (async function visitChildren(createNode, parentNode, context) {
-  const nodes: ContentfulNode[] = Array.isArray(parentNode.children)
-    ? parentNode.children
+  const nodes: ContentfulNode[] = Array.isArray(parentNode.content)
+    ? parentNode.content
     : [];
   let values: Node[] = [];
   let index = -1;

--- a/packages/contentful-to-structured-text/src/visit-children.ts
+++ b/packages/contentful-to-structured-text/src/visit-children.ts
@@ -1,4 +1,9 @@
-import { Handler, Node, ContentfulNode, ContentfulElementNode } from './types';
+import {
+  Handler,
+  Node,
+  ContentfulNode,
+  ContentfulNodeWithContent,
+} from './types';
 import visitNode from './visit-node';
 
 // visitChildren() is for visiting all the children of a node
@@ -34,4 +39,4 @@ export default (async function visitChildren(createNode, parentNode, context) {
   }
 
   return values;
-} as Handler<ContentfulElementNode>);
+} as Handler<ContentfulNodeWithContent>);

--- a/packages/contentful-to-structured-text/src/visit-children.ts
+++ b/packages/contentful-to-structured-text/src/visit-children.ts
@@ -1,9 +1,9 @@
-import { Handler, Node, HastNode, HastElementNode } from './types';
+import { Handler, Node, ContentfulNode, ContentfulElementNode } from './types';
 import visitNode from './visit-node';
 
 // visitChildren() is for visiting all the children of a node
 export default (async function visitChildren(createNode, parentNode, context) {
-  const nodes: HastNode[] = Array.isArray(parentNode.children)
+  const nodes: ContentfulNode[] = Array.isArray(parentNode.children)
     ? parentNode.children
     : [];
   let values: Node[] = [];
@@ -34,4 +34,4 @@ export default (async function visitChildren(createNode, parentNode, context) {
   }
 
   return values;
-} as Handler<HastElementNode>);
+} as Handler<ContentfulElementNode>);

--- a/packages/contentful-to-structured-text/src/visit-node.ts
+++ b/packages/contentful-to-structured-text/src/visit-node.ts
@@ -1,11 +1,16 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
+
 import { Handler, ContentfulNodeWithContent, ContentfulNode } from './types';
 import visitChildren from './visit-children';
 import { helpers } from '@contentful/rich-text-types';
 
 // visitNode() is for visiting a single node
 export default (async function visitNode(createNode, node, context) {
+  if (!node) {
+    return null;
+  }
+
   const handlers = context.handlers;
   let handler;
 

--- a/packages/contentful-to-structured-text/src/visit-node.ts
+++ b/packages/contentful-to-structured-text/src/visit-node.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
-import { Handler, HastElementNode, HastNode } from './types';
+import { Handler, ContentfulElementNode, ContentfulNode } from './types';
 import visitChildren from './visit-children';
 
 // visitNode() is for visiting a single node
@@ -8,19 +8,12 @@ export default (async function visitNode(createNode, node, context) {
   const handlers = context.handlers;
   let handler;
 
-  if (node.type === 'element') {
-    if (
-      typeof node.tagName === 'string' &&
-      typeof handlers[node.tagName] === 'function'
-    ) {
-      handler = handlers[node.tagName];
-    } else {
-      handler = unknownHandler;
-    }
-  } else if (node.type === 'root') {
+  if (node.nodeType === 'document') {
     handler = handlers.root;
-  } else if (node.type === 'text') {
+  } else if (node.nodeType === 'text') {
     handler = handlers.text;
+  } else {
+    handler = handlers[node.tagName] ? handlers[node.tagName] : unknownHandler;
   }
 
   if (typeof handler !== 'function') {
@@ -28,11 +21,11 @@ export default (async function visitNode(createNode, node, context) {
   }
 
   return await handler(createNode, node, context);
-} as Handler<HastNode>);
+} as Handler<ContentfulNode>);
 
 // This is a default handler for unknown nodes.
 // It skips the current node and processes its children.
-const unknownHandler: Handler<HastElementNode> = async function unknownHandler(
+const unknownHandler: Handler<ContentfulElementNode> = async function unknownHandler(
   createNode,
   node,
   context,

--- a/packages/contentful-to-structured-text/src/visit-node.ts
+++ b/packages/contentful-to-structured-text/src/visit-node.ts
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+import { Handler, HastElementNode, HastNode } from './types';
+import visitChildren from './visit-children';
+
+// visitNode() is for visiting a single node
+export default (async function visitNode(createNode, node, context) {
+  const handlers = context.handlers;
+  let handler;
+
+  if (node.type === 'element') {
+    if (
+      typeof node.tagName === 'string' &&
+      typeof handlers[node.tagName] === 'function'
+    ) {
+      handler = handlers[node.tagName];
+    } else {
+      handler = unknownHandler;
+    }
+  } else if (node.type === 'root') {
+    handler = handlers.root;
+  } else if (node.type === 'text') {
+    handler = handlers.text;
+  }
+
+  if (typeof handler !== 'function') {
+    return undefined;
+  }
+
+  return await handler(createNode, node, context);
+} as Handler<HastNode>);
+
+// This is a default handler for unknown nodes.
+// It skips the current node and processes its children.
+const unknownHandler: Handler<HastElementNode> = async function unknownHandler(
+  createNode,
+  node,
+  context,
+) {
+  return visitChildren(createNode, node, context);
+};

--- a/packages/contentful-to-structured-text/src/visit-node.ts
+++ b/packages/contentful-to-structured-text/src/visit-node.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
-import { Handler, ContentfulElementNode, ContentfulNode } from './types';
+import { Handler, ContentfulNodeWithContent, ContentfulNode } from './types';
 import visitChildren from './visit-children';
 import { helpers } from '@contentful/rich-text-types';
 
@@ -28,7 +28,7 @@ export default (async function visitNode(createNode, node, context) {
 
 // This is a default handler for unknown nodes.
 // It skips the current node and processes its children.
-const unknownHandler: Handler<ContentfulElementNode> = async function unknownHandler(
+const unknownHandler: Handler<ContentfulNodeWithContent> = async function unknownHandler(
   createNode,
   node,
   context,

--- a/packages/contentful-to-structured-text/src/visit-node.ts
+++ b/packages/contentful-to-structured-text/src/visit-node.ts
@@ -2,6 +2,7 @@
 // @ts-nocheck
 import { Handler, ContentfulElementNode, ContentfulNode } from './types';
 import visitChildren from './visit-children';
+import { helpers } from '@contentful/rich-text-types';
 
 // visitNode() is for visiting a single node
 export default (async function visitNode(createNode, node, context) {
@@ -9,11 +10,13 @@ export default (async function visitNode(createNode, node, context) {
   let handler;
 
   if (node.nodeType === 'document') {
-    handler = handlers.root;
-  } else if (node.nodeType === 'text') {
+    handler = handlers.document;
+  } else if (helpers.isText(node)) {
     handler = handlers.text;
   } else {
-    handler = handlers[node.tagName] ? handlers[node.tagName] : unknownHandler;
+    handler = handlers[node.nodeType]
+      ? handlers[node.nodeType]
+      : unknownHandler;
   }
 
   if (typeof handler !== 'function') {

--- a/packages/contentful-to-structured-text/src/wrap.ts
+++ b/packages/contentful-to-structured-text/src/wrap.ts
@@ -6,24 +6,15 @@ import { Node } from './types';
 
 // Utility to convert a string into a function which checks a given node’s type
 // for said string.
-const isPhrasing = (node) => {
+const isPhrasing = (node: Node) => {
   return node.type === 'span' || node.type === 'link';
 };
 
+// Wraps consecutive spans and links into a single paragraph
 export function wrap(nodes: Node[]): Node[] {
   return runs(nodes, onphrasing);
 
-  function onphrasing(nodes) {
-    const head = nodes[0];
-
-    if (
-      nodes.length === 1 &&
-      head.type === 'span' &&
-      (head.value === ' ' || head.value === '\n')
-    ) {
-      return [];
-    }
-
+  function onphrasing(nodes: Node[]) {
     return { type: 'paragraph', children: nodes };
   }
 }

--- a/packages/contentful-to-structured-text/src/wrap.ts
+++ b/packages/contentful-to-structured-text/src/wrap.ts
@@ -1,0 +1,149 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+
+import extend from 'extend';
+import { Node } from './types';
+
+// Utility to convert a string into a function which checks a given node’s type
+// for said string.
+const isPhrasing = (node) => {
+  return node.type === 'span' || node.type === 'link';
+};
+
+export function wrap(nodes: Node[]): Node[] {
+  return runs(nodes, onphrasing);
+
+  function onphrasing(nodes) {
+    const head = nodes[0];
+
+    if (
+      nodes.length === 1 &&
+      head.type === 'span' &&
+      (head.value === ' ' || head.value === '\n')
+    ) {
+      return [];
+    }
+
+    return { type: 'paragraph', children: nodes };
+  }
+}
+
+// Wrap all runs of dast phrasing content in `paragraph` nodes.
+function runs(nodes, onphrasing, onnonphrasing) {
+  const nonphrasing = onnonphrasing || identity;
+  const flattened = flatten(nodes);
+  let result = [];
+  let index = -1;
+  let node;
+  let queue;
+
+  while (++index < flattened.length) {
+    node = flattened[index];
+
+    if (isPhrasing(node)) {
+      if (!queue) queue = [];
+      queue.push(node);
+    } else {
+      if (queue) {
+        result = result.concat(onphrasing(queue));
+        queue = undefined;
+      }
+
+      result = result.concat(nonphrasing(node));
+    }
+  }
+
+  if (queue) {
+    result = result.concat(onphrasing(queue));
+  }
+
+  return result;
+}
+
+// Flatten a list of nodes.
+function flatten(nodes) {
+  let flattened = [];
+  let index = -1;
+  let node;
+
+  while (++index < nodes.length) {
+    node = nodes[index];
+
+    // Straddling: some elements are *weird*.
+    // Namely: `map`, `ins`, `del`, and `a`, as they are hybrid elements.
+    // See: <https://html.spec.whatwg.org/#paragraphs>.
+    // Paragraphs are the weirdest of them all.
+    // See the straddling fixture for more info!
+    // `ins` is ignored in mdast, so we don’t need to worry about that.
+    // `map` maps to its content, so we don’t need to worry about that either.
+    // `del` maps to `delete` and `a` to `link`, so we do handle those.
+    // What we’ll do is split `node` over each of its children.
+    if (
+      (node.type === 'delete' || node.type === 'link') &&
+      needed(node.children)
+    ) {
+      flattened = flattened.concat(split(node));
+    } else {
+      flattened.push(node);
+    }
+  }
+
+  return flattened;
+}
+
+// Check if there are non-phrasing mdast nodes returned.
+// This is needed if a fragment is given, which could just be a sentence, and
+// doesn’t need a wrapper paragraph.
+export function needed(nodes: Node[]): boolean {
+  let index = -1;
+  let node;
+
+  while (++index < nodes.length) {
+    node = nodes[index];
+
+    if (!isPhrasing(node) || (node.children && needed(node.children))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function split(node) {
+  return runs(node.children, onphrasing, onnonphrasing);
+
+  // Use `child`, add `parent` as its first child, put the original children
+  // into `parent`.
+  function onnonphrasing(child) {
+    const parent = extend(true, {}, shallow(node));
+    const copy = shallow(child);
+
+    copy.children = [parent];
+    parent.children = child.children;
+
+    return copy;
+  }
+
+  // Use `parent`, put the phrasing run inside it.
+  function onphrasing(nodes) {
+    const parent = extend(true, {}, shallow(node));
+    parent.children = nodes;
+    return parent;
+  }
+}
+
+function identity(n) {
+  return n;
+}
+
+function shallow(node) {
+  const copy = {};
+  let key;
+
+  for (key in node) {
+    if ({}.hasOwnProperty.call(node, key) && key !== 'children') {
+      copy[key] = node[key];
+    }
+  }
+
+  return copy;
+}

--- a/packages/contentful-to-structured-text/tsconfig.json
+++ b/packages/contentful-to-structured-text/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declarationDir": "dist/types",
+    "outDir": "dist/lib",
+    "typeRoots": [
+      "../../node_modules/@types",
+      "node_modules/@types",
+      "src/typings"
+    ]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Added the`datocms-contentful-to-structured-text` package:

- Converts Contentful `Rich Text` to valid DatoCMS `Structured Text`. 
- Allows users to create custom handlers for each Contentful block.
- Users can specify permitted DatoCMS blocks and marks.
- Does not validate `Rich Text` before converting.
- Ignores embeds and assets.