### PR TITLE
[WIP] Separate blocks type from links type

### DIFF
--- a/packages/utils/src/guards.ts
+++ b/packages/utils/src/guards.ts
@@ -98,10 +98,10 @@ export function isThematicBreak(node: Node): node is ThematicBreak {
   return node.type === thematicBreakNodeType;
 }
 
-export function isStructuredText<R extends Record>(
+export function isStructuredText<R1 extends Record, R2 extends Record = R1>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   obj: any,
-): obj is StructuredText<R> {
+): obj is StructuredText<R1, R2> {
   return obj && 'value' in obj && isDocument(obj.value);
 }
 

--- a/packages/utils/src/render.ts
+++ b/packages/utils/src/render.ts
@@ -112,10 +112,16 @@ export function render<
   H extends TrasformFn,
   T extends TrasformFn,
   F extends TrasformFn,
-  R extends Record
+  R1 extends Record,
+  R2 extends Record = R1
 >(
   adapter: Adapter<H, T, F>,
-  structuredTextOrNode: StructuredText<R> | Document | Node | null | undefined,
+  structuredTextOrNode:
+    | StructuredText<R1, R2>
+    | Document
+    | Node
+    | null
+    | undefined,
   renderRules: RenderRule<H, T, F>[],
 ): RenderResult<H, T, F> {
   if (!structuredTextOrNode) {
@@ -124,7 +130,7 @@ export function render<
 
   const result = transformNode(
     adapter,
-    isStructuredText<R>(structuredTextOrNode)
+    isStructuredText<R1, R2>(structuredTextOrNode)
       ? structuredTextOrNode.value.document
       : isDocument(structuredTextOrNode)
       ? structuredTextOrNode.document

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -440,13 +440,13 @@ export type NodeType =
  * and embedded within the flow of the text.
  */
 
-export type StructuredText<R extends Record = Record> = {
+export type StructuredText<R1 extends Record = Record, R2 extends Record = R1> = {
   /** A DatoCMS compatible document */
   value: Document;
   /** Blocks associated with the Structured Text */
-  blocks?: R[];
+  blocks?: R1[];
   /** Links associated with the Structured Text */
-  links?: R[];
+  links?: R2[];
 };
 
 export type Record = {


### PR DESCRIPTION
This PR separates the `blocks` property to its generics, allowing users to specify different types for their `links` and `blocks`.

## Compatibility
When this type is used with one type parameter, the type of `links` and `blocks` will be the same, ensuring the same behaviour matching the older versions.

## Considerations
 * `generic-html-renderer` doesn't work this kind of backward compatibility trick since it accepts other type parameters other than Record. I'll just make a breaking change in this package since it doesn't seem to be recommended for end-users.

## Related links
* https://github.com/datocms/react-datocms/issues/50
* https://community.datocms.com/t/bug-react-datocms-structuredtexts-incorrect-typings-on-blocks-links/2693