### PR TITLE
Create isEmptyOrInvalid helper function

### DIFF
--- a/packages/utils/src/is-empty-or-invalid.ts
+++ b/packages/utils/src/is-empty-or-invalid.ts
@@ -1,0 +1,19 @@
+import { validate } from "./validate";
+
+export default function isEmptyOrInvalid(structuredText: any): boolean {
+  if (!structuredText) {
+    return true;
+  }
+
+  const validation = validate(structuredText)
+  if (!validation.valid) {
+    console.error(validation.message);
+    return true;
+  }
+
+  if (structuredText.value.document.children[0].children.value === "") {
+    return true;
+  }
+
+  return false;
+}

--- a/packages/utils/src/is-empty-or-invalid.ts
+++ b/packages/utils/src/is-empty-or-invalid.ts
@@ -5,13 +5,13 @@ export default function isEmptyOrInvalid(structuredText: any): boolean {
     return true;
   }
 
-  const validation = validate(structuredText)
+  const validation = validate(structuredText.value)
   if (!validation.valid) {
     console.error(validation.message);
     return true;
   }
 
-  if (structuredText.value.document.children[0].children.value === "") {
+  if (structuredText.value.document.children[0].children[0].value === '') {
     return true;
   }
 


### PR DESCRIPTION
This helper has as purpose to validate and null-check structuredText fields returned from DatoCMS.

## Situation
> - An admin decides to not fill in a certain structuredText field.
> - The returned value through GraphQL will be paragraph with an empty <span>.
> - On the front-end you will end up with <p><p> which could extra invisible margins in some cases.