### PR TITLE
Fix broken link in readme

### DIFF
--- a/packages/html-to-structured-text/README.md
+++ b/packages/html-to-structured-text/README.md
@@ -115,7 +115,7 @@ To ensure that a valid `dast` is generated the default handlers also check that 
 
 Information about the parent `dast` node name is available in `context.parentNodeType`.
 
-Please take a look at the [default handlers implementation](./handlers.ts) for examples.
+Please take a look at the [default handlers implementation](./src/handlers.ts) for examples.
 
 The default handlers are available on `context.defaultHandlers`.
 

--- a/packages/html-to-structured-text/package.json
+++ b/packages/html-to-structured-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-html-to-structured-text",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Convert HTML (or a `hast` syntax tree) to a valid DatoCMS Structured Text `dast` document",
   "keywords": [
     "datocms",


### PR DESCRIPTION
The link to handlers.ts was missing the src/ directory